### PR TITLE
Reduce restriction on builds, change line endings to auto, update plugins

### DIFF
--- a/maven-plugin/src/main/java/net/revelc/code/formatter/LineEnding.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/LineEnding.java
@@ -21,7 +21,7 @@ package net.revelc.code.formatter;
  */
 public enum LineEnding {
 
-	AUTO(System.getProperty("line.separator")), KEEP(null), LF("\n"), CRLF("\r\n"), CR("\r"), UNKNOW(null);
+	AUTO(SystemUtil.LINE_SEPARATOR), KEEP(null), LF("\n"), CRLF("\r\n"), CR("\r"), UNKNOW(null);
 
 	private final String chars;
 

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/SystemUtil.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/SystemUtil.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2010-2015. All work is copyrighted to their respective
+ * author(s), unless otherwise stated.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.revelc.code.formatter;
+
+/**
+ * Private SystemUtil Enum Class.
+ */
+public enum SystemUtil {
+
+	;
+
+	public static final String LINE_SEPARATOR = System.getProperty("line.separator");
+}

--- a/pom.xml
+++ b/pom.xml
@@ -388,7 +388,7 @@
                 <executions>
                     <execution>
                         <goals>
-                            <goal>validate</goal>
+                            <goal>format</goal>
                         </goals>
                     </execution>
                 </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -127,7 +127,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-clean-plugin</artifactId>
-                    <version>2.6.1</version>
+                    <version>3.0.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -376,7 +376,7 @@
                         <exclude>**/src/test/resources/**</exclude>
                         <exclude>**/target/**</exclude>
                     </excludes>
-                    <lineEnding>LF</lineEnding>
+                    <lineEnding>AUTO</lineEnding>
                 </configuration>
                 <dependencies>
                     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -121,8 +121,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.2</version>
-                    <!-- drop back from 3.3.3 as it breaks on lineEndings.java -->
+                    <version>3.4</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         </contributor>
     </contributors>
     <prerequisites>
-        <maven>3.1.1</maven>
+        <maven>3.2.5</maven>
     </prerequisites>
     <modules>
         <module>formatters</module>
@@ -110,7 +110,7 @@
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>
         <maven.compiler.target>1.7</maven.compiler.target>
-        <maven.min-version>3.1.1</maven.min-version>
+        <maven.min-version>3.2.5</maven.min-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
We need to validate only in CI builds - ie on travis ci not local builds as that ends up requiring developers to use eclipse to format which violates the spirit of the plugin.  If we don't enforce it there yet, we should.  For now, reducing the restriction locally.
