### PR TITLE
General Code Improvement 1

### DIFF
--- a/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/internal/FormatterProjectConfigurator.java
+++ b/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/internal/FormatterProjectConfigurator.java
@@ -149,7 +149,7 @@ public class FormatterProjectConfigurator extends AbstractProjectConfigurator {
         }
     }
 
-    private void eval(Preferences prefs, String spacer, StringBuilder sb) throws Exception {
+    private static void eval(Preferences prefs, String spacer, StringBuilder sb) throws Exception {
         String[] children = prefs.childrenNames();
         for (String child : children) {
             sb.append(spacer).append(child).append("\n");

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/AbstractCacheableFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/AbstractCacheableFormatter.java
@@ -79,7 +79,7 @@ public abstract class AbstractCacheableFormatter {
         }
     }
 
-    private String fixLineEnding(String code, LineEnding ending) {
+    private static String fixLineEnding(String code, LineEnding ending) {
         if (ending == LineEnding.KEEP) {
             return null;
         }

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -80,6 +80,7 @@ import net.revelc.code.formatter.model.ConfigReader;
 @Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = false)
 public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
 
+    private static final String FILE_S = " file(s)";
     /** The Constant CACHE_PROPERTIES_FILENAME. */
     private static final String CACHE_PROPERTIES_FILENAME = "maven-java-formatter-cache.properties";
     /** The Constant DEFAULT_INCLUDES. */
@@ -285,9 +286,9 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
 
             long endClock = System.currentTimeMillis();
 
-            log.info("Successfully formatted:          " + rc.successCount + " file(s)");
-            log.info("Fail to format:                  " + rc.failCount + " file(s)");
-            log.info("Skipped:                         " + rc.skippedCount + " file(s)");
+            log.info("Successfully formatted:          " + rc.successCount + FILE_S);
+            log.info("Fail to format:                  " + rc.failCount + FILE_S);
+            log.info("Skipped:                         " + rc.skippedCount + FILE_S);
             log.info("Approximate time taken:          " + ((endClock - startClock) / 1000) + "s");
         }
     }

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/RuleSet.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/RuleSet.java
@@ -28,6 +28,9 @@ import org.apache.commons.digester3.RuleSetBase;
  */
 class RuleSet extends RuleSetBase {
 
+    
+    private static final String PROFILES_PROFILE = "profiles/profile";
+    private static final String PROFILES_PROFILE_SETTING = PROFILES_PROFILE + "/setting";
     /**
      * Adds the rule instances.
      *
@@ -37,15 +40,15 @@ class RuleSet extends RuleSetBase {
     @Override
     public void addRuleInstances(Digester digester) {
         digester.addObjectCreate("profiles", Profiles.class);
-        digester.addObjectCreate("profiles/profile", Profile.class);
-        digester.addObjectCreate("profiles/profile/setting", Setting.class);
+        digester.addObjectCreate(PROFILES_PROFILE, Profile.class);
+        digester.addObjectCreate(PROFILES_PROFILE_SETTING, Setting.class);
 
-        digester.addSetNext("profiles/profile", "addProfile");
-        digester.addSetNext("profiles/profile/setting", "addSetting");
+        digester.addSetNext(PROFILES_PROFILE, "addProfile");
+        digester.addSetNext(PROFILES_PROFILE_SETTING, "addSetting");
 
-        digester.addSetProperties("profiles/profile", "kind", "kind");
-        digester.addSetProperties("profiles/profile/setting", "id", "id");
-        digester.addSetProperties("profiles/profile/setting", "value", "value");
+        digester.addSetProperties(PROFILES_PROFILE, "kind", "kind");
+        digester.addSetProperties(PROFILES_PROFILE_SETTING, "id", "id");
+        digester.addSetProperties(PROFILES_PROFILE_SETTING, "value", "value");
     }
 
 }


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1192 String literals should not be duplicated
squid:S2325 'private' methods that don't access instance data should be 'static'

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1192
https://dev.eclipse.org/sonar/rules/show/squid:S2325

Please let me know if you have any questions.

Zeeshan Asghar
