### PR TITLE
General Code Improvement 2

### DIFF
--- a/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/FormatterCore.java
+++ b/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/FormatterCore.java
@@ -19,4 +19,7 @@ package net.revelc.code.formatter.connector;
 public class FormatterCore {
     public static final String PLUGIN_ID = "net.revelc.code.formatter.connector";
 
+    private FormatterCore() {
+        throw new InstantiationError("Must not instantiate this class.");
+    }
 }

--- a/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/internal/FormatterProjectConfigurator.java
+++ b/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/internal/FormatterProjectConfigurator.java
@@ -17,11 +17,14 @@
 package net.revelc.code.formatter.connector.internal;
 
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStreamWriter;
+import java.nio.charset.Charset;
 import java.util.List;
-
+import java.util.logging.Logger;
 import org.apache.maven.plugin.MojoExecution;
 import org.codehaus.plexus.util.xml.Xpp3Dom;
 import org.codehaus.plexus.util.xml.Xpp3DomBuilder;
@@ -46,6 +49,7 @@ import net.revelc.code.formatter.connector.FormatterCore;
 
 public class FormatterProjectConfigurator extends AbstractProjectConfigurator {
 
+    private static final Logger LOGGER = Logger.getLogger(FormatterProjectConfigurator.class.getName());
     public enum Formatter {
         JAVA("configFile", "src/config/eclipse/formatter/java.xml");
 
@@ -137,15 +141,15 @@ public class FormatterProjectConfigurator extends AbstractProjectConfigurator {
         try {
             eval(prefs, "\t", sb);
         } catch (Exception e1) {
-            e1.printStackTrace();
+            LOGGER.info("Exception in eval " + e1.getMessage());
         }
 
         File f = new File("tree.txt");
-        try (final FileWriter fw = new FileWriter(f)) {
-            fw.write(sb.toString().toCharArray());
+        try (final OutputStreamWriter osw = new OutputStreamWriter(new FileOutputStream(f), Charset.forName("UTF-8"))) {
+            osw.write(sb.toString().toCharArray());
             f.getAbsolutePath();
         } catch (IOException e1) {
-            e1.printStackTrace();
+            LOGGER.info("Exception in writing in tree.txt " + e1.getMessage());
         }
     }
 

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/ConfigReader.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/ConfigReader.java
@@ -55,7 +55,7 @@ public class ConfigReader {
 
         Profiles profiles = (Profiles) result;
         List<Map<String, String>> list = profiles.getProfiles();
-        if (list.size() == 0) {
+        if (list.isEmpty()) {
             throw new ConfigReadException("No profile in config file of kind: " + Profiles.PROFILE_KIND);
         }
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 

squid:S1155  Collection.isEmpty() should be used to test for emptiness
squid:S1118 Utility classes should not have public constructors
squid:S1148  Throwable.printStackTrace(...) should not be called

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/rules/show/squid:S1155
https://dev.eclipse.org/sonar/rules/show/squid:S1118 
https://dev.eclipse.org/sonar/rules/show/squid:S1148  

Please let me know if you have any questions.

Zeeshan Asghar
