### PR TITLE
Fix warnings and javadocs

### DIFF
--- a/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/internal/FormatterProjectConfigurator.java
+++ b/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/internal/FormatterProjectConfigurator.java
@@ -18,7 +18,6 @@ package net.revelc.code.formatter.connector.internal;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStreamWriter;

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/Formatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/Formatter.java
@@ -17,12 +17,9 @@
 package net.revelc.code.formatter;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.Map;
 
-import org.apache.maven.plugin.MojoExecutionException;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
-import org.eclipse.jface.text.BadLocationException;
 
 /**
  * @author marvin.froeder
@@ -31,23 +28,11 @@ public interface Formatter {
 
     /**
      * Initialize the {@link CodeFormatter} instance to be used by this component.
-     * 
-     * @param log
-     * @param targetDirectory
-     * @throws MojoExecutionException
      */
     public abstract void init(Map<String, String> options, ConfigurationSource cfg);
 
     /**
      * Format individual file.
-     * 
-     * @param file
-     * @param rc
-     * @param hashCache
-     * @param basedirPath
-     * @return
-     * @throws IOException
-     * @throws BadLocationException
      */
     public abstract Result formatFile(File file, LineEnding ending, boolean dryRun);
 

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -387,8 +387,6 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * @param rc the rc
      * @param hashCache the hash cache
      * @param basedirPath the basedir path
-     * @throws MojoFailureException
-     * @throws MojoExecutionException
      */
     private void formatFile(File file, ResultCollector rc, Properties hashCache, String basedirPath)
             throws MojoFailureException, MojoExecutionException {
@@ -415,8 +413,6 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * @param basedirPath the basedir path
      * @throws IOException Signals that an I/O exception has occurred.
      * @throws BadLocationException the bad location exception
-     * @throws MojoFailureException
-     * @throws MojoExecutionException
      */
     protected void doFormatFile(File file, ResultCollector rc, Properties hashCache, String basedirPath, boolean dryRun)
             throws IOException, BadLocationException, MojoFailureException, MojoExecutionException {

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/LineEnding.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/LineEnding.java
@@ -35,8 +35,6 @@ public enum LineEnding {
 
     /**
      * Returns the most occurring line-ending characters in the file text or null if no line-ending occurs the most.
-     * 
-     * @return
      */
     public static LineEnding determineLineEnding(String fileDataString) {
         int lfCount = 0;

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/RuleSet.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/RuleSet.java
@@ -35,7 +35,7 @@ class RuleSet extends RuleSetBase {
      * Adds the rule instances.
      *
      * @param digester the digester
-     * @see org.apache.commons.digester3.RuleSetBase#addRuleInstances(org.apache.commons.digester.Digester)
+     * @see org.apache.commons.digester3.RuleSetBase#addRuleInstances(org.apache.commons.digester3.Digester)
      */
     @Override
     public void addRuleInstances(Digester digester) {

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/LineEndingTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/LineEndingTest.java
@@ -48,8 +48,6 @@ public class LineEndingTest {
 
     /**
      * Test successfully determining CRLF line ending.
-     * 
-     * @throws Exception
      */
     @Test
     public void test_success_read_line_endings_crlf() throws Exception {
@@ -60,8 +58,6 @@ public class LineEndingTest {
 
     /**
      * Test successfully determining LF line ending.
-     * 
-     * @throws Exception
      */
     @Test
     public void test_success_read_line_endings_lf() throws Exception {
@@ -72,8 +68,6 @@ public class LineEndingTest {
 
     /**
      * Test successfully determining CR line ending.
-     * 
-     * @throws Exception
      */
     @Test
     public void test_success_read_line_endings_cr() throws Exception {
@@ -84,8 +78,6 @@ public class LineEndingTest {
 
     /**
      * Test successfully determining LF line ending with mixed endings.
-     * 
-     * @throws Exception
      */
     @Test
     public void test_success_read_line_endings_mixed_lf() throws Exception {
@@ -97,8 +89,6 @@ public class LineEndingTest {
     /**
      * Test successfully determining AUTO line ending with mixed endings and no
      * clear majority.
-     * 
-     * @throws Exception
      */
     @Test
     public void test_success_read_line_endings_mixed_auto() throws Exception {
@@ -109,8 +99,6 @@ public class LineEndingTest {
 
     /**
      * Test successfully determining AUTO line ending with no endings.
-     * 
-     * @throws Exception
      */
     @Test
     public void test_success_read_line_endings_none_auto() throws Exception {

--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,9 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>2.10.3</version>
+                    <configuration>
+                        <quiet>true</quiet>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -473,9 +476,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.10.3</version>
-                <configuration>
-                    <failOnError>false</failOnError>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -545,6 +545,26 @@
                         </executions>
                     </plugin>
                 </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>jdk8</id>
+            <activation>
+                <jdk>[1.8,1.9)</jdk>
+            </activation>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.apache.maven.plugins</groupId>
+                            <artifactId>maven-javadoc-plugin</artifactId>
+                            <configuration>
+                                <javadocVersion>1.8</javadocVersion>
+                                <additionalparam>-Xdoclint:all,-Xdoclint:-missing</additionalparam>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
             </build>
         </profile>
         <profile>
@@ -624,7 +644,7 @@
                                             <pluginExecutionFilter>
                                                 <groupId>org.apache.maven.plugins</groupId>
                                                 <artifactId>maven-plugin-plugin</artifactId>
-                                                <versionRange>[3.4,)</versionRange>
+                                                <versionRange>[0,)</versionRange>
                                                 <goals>
                                                     <goal>helpmojo</goal>
                                                     <goal>descriptor</goal>
@@ -638,9 +658,36 @@
                                             <pluginExecutionFilter>
                                                 <groupId>org.apache.maven.plugins</groupId>
                                                 <artifactId>maven-enforcer-plugin</artifactId>
-                                                <versionRange>[1.4.1,)</versionRange>
+                                                <versionRange>[0,)</versionRange>
                                                 <goals>
                                                     <goal>enforce</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>com.github.ekryd.sortpom</groupId>
+                                                <artifactId>sortpom-maven-plugin</artifactId>
+                                                <versionRange>[0,)</versionRange>
+                                                <goals>
+                                                    <goal>sort</goal>
+                                                    <goal>verify</goal>
+                                                </goals>
+                                            </pluginExecutionFilter>
+                                            <action>
+                                                <ignore />
+                                            </action>
+                                        </pluginExecution>
+                                        <pluginExecution>
+                                            <pluginExecutionFilter>
+                                                <groupId>com.marvinformatics.formatter</groupId>
+                                                <artifactId>formatter-maven-plugin</artifactId>
+                                                <versionRange>[0,)</versionRange>
+                                                <goals>
+                                                    <goal>format</goal>
                                                 </goals>
                                             </pluginExecutionFilter>
                                             <action>

--- a/support/src/main/java/net/revelc/code/formatter/support/text/Template.java
+++ b/support/src/main/java/net/revelc/code/formatter/support/text/Template.java
@@ -45,7 +45,7 @@ public final class Template {
 
     /**
      * Formats the applied args into the template content.
-     * <p />
+     * <p>
      * The supplied locale is used to format the text.
      * @param locale Locale to use for formatting
      * @param args Arguments to use as source data

--- a/support/src/test/java/net/revelc/code/formatter/support/io/ResourceTest.java
+++ b/support/src/test/java/net/revelc/code/formatter/support/io/ResourceTest.java
@@ -23,7 +23,6 @@ import static net.revelc.code.formatter.support.io.Resource.forPath;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.*;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.Scanner;
 
@@ -62,10 +61,8 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#asInputStream()}.
-     * <p />
+     * <p>
      * This test case assumes a valid resource path in the default package.
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @SuppressWarnings("resource")
     @Test
@@ -78,10 +75,8 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#asInputStream()}.
-     * <p />
+     * <p>
      * This test case assumes a valid resource path in a sub-package.
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @SuppressWarnings("resource")
     @Test
@@ -94,10 +89,8 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#asInputStream()}.
-     * <p />
+     * <p>
      * This test case assumes an invalid resource path that will induce failure.
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @Test(expected = UnknownResourceException.class)
     public void testAsInputStreamInvalidResource() throws UnknownResourceException {
@@ -106,10 +99,8 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#asString()}.
-     * <p />
+     * <p>
      * This test case assumes a valid resource path.
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @Test
     public void testAsString() throws UnknownResourceException {
@@ -119,10 +110,8 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#toInputStream()}.
-     * <p />
+     * <p>
      * This test case assumes a valid resource path.
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @SuppressWarnings("resource")
     @Test
@@ -135,10 +124,8 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#toInputStream()}.
-     * <p />
+     * <p>
      * This test case assumes a valid resource path.
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @SuppressWarnings("resource")
     @Test
@@ -151,10 +138,8 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#getPrefix()}.
-     * <p />
+     * <p>
      * This test case assumes a classpath resource
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @Test
     public void testGetPrefixClasspath() throws UnknownResourceException {
@@ -164,10 +149,8 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#getPrefix()}.
-     * <p />
+     * <p>
      * This test case assumes a file resource
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @Test
     public void testGetPrefixFile() throws UnknownResourceException {
@@ -177,7 +160,6 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#getPath()}.
-     * @throws UnknownResourceException 
      */
     @Test
     public void testGetPathClasspath() throws UnknownResourceException {
@@ -187,7 +169,6 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#getPath()}.
-     * @throws UnknownResourceException 
      */
     @Test
     public void testGetPathFile() throws UnknownResourceException {
@@ -197,7 +178,6 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#getNativePath()}.
-     * @throws UnknownResourceException 
      */
     @Test
     public void testGetNativePathClasspath() throws UnknownResourceException {
@@ -207,7 +187,6 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#getNativePath()}.
-     * @throws UnknownResourceException 
      */
     @Test
     public void testGetNativePathFile() throws UnknownResourceException {
@@ -217,8 +196,6 @@ public class ResourceTest {
 
     /**
      * Test method for {@link Resource#forPath(java.lang.String)}.
-     * @throws IOException 
-     * @throws UnknownResourceException 
      */
     @Test
     public void testForPath() throws UnknownResourceException {

--- a/support/src/test/java/net/revelc/code/formatter/support/text/TemplateTest.java
+++ b/support/src/test/java/net/revelc/code/formatter/support/text/TemplateTest.java
@@ -41,7 +41,7 @@ public class TemplateTest {
     }
 
     /**
-     * Test method for {@link Template#format(Locale, java.lang.String[])}.
+     * Test method for {@link Template#formatWithLocale(Locale, String...)}.
      */
     @Test
     public final void testFormatWithLocaleStringArray() {
@@ -53,7 +53,7 @@ public class TemplateTest {
 
     /**
      * Test method for {@link Template#as(java.lang.String)}.
-     * <p />
+     * <p>
      * This test case assumes a valid template string.
      */
     @Test
@@ -65,7 +65,7 @@ public class TemplateTest {
 
     /**
      * Test method for {@link Template#as(java.lang.String)}.
-     * <p />
+     * <p>
      * This test case assumes a null template string.
      */
     @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Fixes malformed javadocs and bad html in javadocs
Add javadoc configuration to work with jdk8
Remove unused imports
Add some plugin executions to m2e ignore to avoid Eclipse warnings
