### PR TITLE
#109 : prevent exeception if only one config file is provided.

### DIFF
--- a/maven-plugin/src/main/java/net/revelc/code/formatter/Formatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/Formatter.java
@@ -19,8 +19,6 @@ package net.revelc.code.formatter;
 import java.io.File;
 import java.util.Map;
 
-import org.eclipse.jdt.core.formatter.CodeFormatter;
-
 /**
  * @author marvin.froeder
  */
@@ -35,5 +33,10 @@ public interface Formatter {
      * Format individual file.
      */
     public abstract Result formatFile(File file, LineEnding ending, boolean dryRun);
+
+    /**
+     * return true if this formatter have been initialized
+     */
+    boolean isInitialized();
 
 }

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
@@ -69,4 +69,9 @@ public class JavaFormatter extends AbstractCacheableFormatter implements Formatt
         return formattedCode;
     }
 
+    @Override
+    public boolean isInitialized() {
+        return formatter != null;
+    }
+
 }

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/javascript/JavascriptFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/javascript/JavascriptFormatter.java
@@ -62,4 +62,9 @@ public class JavascriptFormatter extends AbstractCacheableFormatter implements F
         return formattedCode;
     }
 
+    @Override
+    public boolean isInitialized() {
+        return formatter != null;
+    }
+
 }

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
@@ -37,6 +37,51 @@ import com.google.common.io.Files;
 
 public abstract class AbstractFormatterTest {
 
+    public static class TestConfigurationSource implements ConfigurationSource {
+
+        /**
+         * 
+         */
+        private final File targetDir;
+
+        /**
+         * @param targetDir
+         */
+        public TestConfigurationSource(File targetDir) {
+            this.targetDir = targetDir;
+        }
+
+        @Override
+        public File getTargetDirectory() {
+            return this.targetDir;
+        }
+
+        @Override
+        public Log getLog() {
+            return new SystemStreamLog();
+        }
+
+        @Override
+        public Charset getEncoding() {
+            return Charsets.UTF_8;
+        }
+
+        @Override
+        public String getCompilerSources() {
+            return "1.8";
+        }
+
+        @Override
+        public String getCompilerCompliance() {
+            return "1.8";
+        }
+
+        @Override
+        public String getCompilerCodegenTargetPlatform() {
+            return "1.8";
+        }
+    }
+
     protected void doTestFormat(Formatter formatter, String fileUnderTest, String expectedSha1) throws IOException {
         File originalSourceFile = new File("src/test/resources/", fileUnderTest);
         File sourceFile = new File("target/test-classes/", fileUnderTest);
@@ -46,38 +91,7 @@ public abstract class AbstractFormatterTest {
         Map<String, String> options = new HashMap<>();
         final File targetDir = new File("target/testoutput");
         targetDir.mkdirs();
-        formatter.init(options, new ConfigurationSource() {
-
-            @Override
-            public File getTargetDirectory() {
-                return targetDir;
-            }
-
-            @Override
-            public Log getLog() {
-                return new SystemStreamLog();
-            }
-
-            @Override
-            public Charset getEncoding() {
-                return Charsets.UTF_8;
-            }
-
-            @Override
-            public String getCompilerSources() {
-                return "1.8";
-            }
-
-            @Override
-            public String getCompilerCompliance() {
-                return "1.8";
-            }
-
-            @Override
-            public String getCompilerCodegenTargetPlatform() {
-                return "1.8";
-            }
-        });
+        formatter.init(options, new TestConfigurationSource(targetDir));
         Result r = formatter.formatFile(sourceFile, LineEnding.CRLF, false);
         Assert.assertEquals(Result.SUCCESS, r);
 

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
@@ -16,6 +16,12 @@
  */
 package net.revelc.code.formatter.java;
 
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+
 import org.junit.Test;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
@@ -29,6 +35,16 @@ public class JavaFormatterTest extends AbstractFormatterTest {
     @Test
     public void testDoFormatFile() throws Exception {
         doTestFormat(new JavaFormatter(), "AnyClass.java", "c731dfe964279840da44f9c0f05b2020a7bbe606");
+    }
+
+    @Test
+    public void testIsIntialized() throws Exception {
+        JavaFormatter javaFormatter = new JavaFormatter();
+        assertFalse(javaFormatter.isInitialized());
+        final File targetDir = new File("target/testoutput");
+        targetDir.mkdirs();
+        javaFormatter.init(new HashMap<String, String>(), new AbstractFormatterTest.TestConfigurationSource(targetDir));
+        assertTrue(javaFormatter.isInitialized());
     }
 
 }

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/javascript/JavascriptFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/javascript/JavascriptFormatterTest.java
@@ -16,6 +16,12 @@
  */
 package net.revelc.code.formatter.javascript;
 
+import static org.junit.Assert.*;
+
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+
 import org.junit.Test;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
@@ -26,6 +32,16 @@ public class JavascriptFormatterTest extends AbstractFormatterTest {
     @Test
     public void testDoFormatFile() throws Exception {
         doTestFormat(new JavascriptFormatter(), "AnyJS.js", "21b93e8beab08640dccf4d104940ec9b1490c5ea");
+    }
+
+    @Test
+    public void testIsIntialized() throws Exception {
+        JavascriptFormatter jsFormatter = new JavascriptFormatter();
+        assertFalse(jsFormatter.isInitialized());
+        final File targetDir = new File("target/testoutput");
+        targetDir.mkdirs();
+        jsFormatter.init(new HashMap<String, String>(), new AbstractFormatterTest.TestConfigurationSource(targetDir));
+        assertTrue(jsFormatter.isInitialized());
     }
 
 }


### PR DESCRIPTION
related to #109, a second pull request without adding any maven parameter.
It checks if one config is present and then executes without exception.
If the 2 configs are not found an exception is thrown.
I did not create a test for the FormatterMojo class with a lack of time.
