### PR TITLE
[pom] Drop back to marvinformatics 1.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -438,7 +438,7 @@
             <plugin>
                 <groupId>com.marvinformatics.formatter</groupId>
                 <artifactId>formatter-maven-plugin</artifactId>
-                <version>1.8.0</version>
+                <version>1.7.0</version>
                 <configuration>
                     <sourceDirectory>${project.basedir}</sourceDirectory>
                     <excludes>


### PR DESCRIPTION
Drop back to 1.7.0 as 1.8.0 requires jdk8
