### PR TITLE
Fixes Issue #123 Formatter attempts to format readonly files (#1)

### DIFF
--- a/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -280,7 +280,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             String basedirPath = getBasedirPath();
             for (int i = 0, n = files.size(); i < n; i++) {
                 File file = files.get(i);
-                if (file.exists()) {
+                if (file.exists() && file.canWrite()) {
                     formatFile(file, rc, hashCache, basedirPath);
                 }
             }
@@ -319,7 +319,10 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
 
         List<File> foundFiles = new ArrayList<>();
         for (String filename : ds.getIncludedFiles()) {
-            foundFiles.add(new File(newBasedir, filename));
+            File foundFile = new File(newBasedir, filename);
+            if(foundFile.canWrite()){
+                foundFiles.add(foundFile);
+            }
         }
         return foundFiles;
     }


### PR DESCRIPTION
* Block formatting of non writable files.  

This is for scm's that require files to be checked out before editing.  For example, perforce.

* Update FormatterMojo.java