### PR TITLE
[config] Add support for multimodule build with file in parent only

### DIFF
--- a/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.charset.Charset;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -562,6 +563,17 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
 
         this.getLog().debug("Using search path at: " + this.basedir.getAbsolutePath());
         this.resourceManager.addSearchPath(FileResourceLoader.ID, this.basedir.getAbsolutePath());
+
+        // Add parents
+        File parent = new File(Paths.get(this.basedir.toURI()).getParent() + File.separator + "pom.xml");
+        this.getLog().debug("Probing pom at: " + parent.getAbsolutePath());
+        while (parent.exists()) {
+            this.getLog().debug("Using search path at: " + parent.getParent());
+            this.resourceManager.addSearchPath(FileResourceLoader.ID, parent.getParent());
+
+            parent = new File(Paths.get(parent.toURI()).getParent().getParent() + File.separator + "pom.xml");
+            this.getLog().debug("Probing pom at: " + parent.getAbsolutePath());
+        }
 
         try (InputStream configInput = this.resourceManager.getResourceAsInputStream(newConfigFile)) {
             return new ConfigReader().read(configInput);

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -213,6 +213,15 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
     @Parameter(defaultValue = "false", alias = "skip", property = "formatter.skip")
     private Boolean skipFormatting;
 
+    /**
+     * Add configuration search for all parents of module executing formatting. The
+     * first found configuration including in module will be used.
+     * 
+     * @since 1.6.0
+     */
+    @Parameter(defaultValue = "false", property = "addConfigSearchInParents")
+    private Boolean addConfigSearchInParents;
+
     private JavaFormatter javaFormatter = new JavaFormatter();
 
     private JavascriptFormatter jsFormatter = new JavascriptFormatter();
@@ -564,15 +573,17 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         this.getLog().debug("Using search path at: " + this.basedir.getAbsolutePath());
         this.resourceManager.addSearchPath(FileResourceLoader.ID, this.basedir.getAbsolutePath());
 
-        // Add parents
-        File parent = new File(Paths.get(this.basedir.toURI()).getParent() + File.separator + "pom.xml");
-        this.getLog().debug("Probing pom at: " + parent.getAbsolutePath());
-        while (parent.exists()) {
-            this.getLog().debug("Using search path at: " + parent.getParent());
-            this.resourceManager.addSearchPath(FileResourceLoader.ID, parent.getParent());
-
-            parent = new File(Paths.get(parent.toURI()).getParent().getParent() + File.separator + "pom.xml");
+        // Add parents for searching
+        if (this.addConfigSearchInParents) {
+            File parent = new File(Paths.get(this.basedir.toURI()).getParent() + File.separator + "pom.xml");
             this.getLog().debug("Probing pom at: " + parent.getAbsolutePath());
+            while (parent.exists()) {
+                this.getLog().debug("Using search path at: " + parent.getParent());
+                this.resourceManager.addSearchPath(FileResourceLoader.ID, parent.getParent());
+
+                parent = new File(Paths.get(parent.toURI()).getParent().getParent() + File.separator + "pom.xml");
+                this.getLog().debug("Probing pom at: " + parent.getAbsolutePath());
+            }
         }
 
         try (InputStream configInput = this.resourceManager.getResourceAsInputStream(newConfigFile)) {


### PR DESCRIPTION
This code supports multimodule builds by allow a single format xml file in the root directory.  It will recursively read back until there are no more root pom(s) before it stops looking for the first format xml it comes across.  Tested this via [Waffle](https://github.com/dblock/waffle) as it has many layers and was well suited to test this type of usage as it is a bit complex.  Logging exists in debut to show what is going on during searching.