### PR TITLE
Add ability to fail build if file required formatting

### DIFF
--- a/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -212,6 +212,15 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
     @Parameter(defaultValue = "false", alias = "skip", property = "formatter.skip")
     private Boolean skipFormatting;
 
+
+    /**
+     * If you want to fail a build if any files were found not adhering to the formatter, you can
+     * do so with this flag.
+     * This is useful if you want to fail builds in continuous build environments.
+     */
+    @Parameter(defaultValue = "false", property = "failIfNotFormatted")
+    private Boolean failIfNotFormatted;
+
     private JavaFormatter javaFormatter = new JavaFormatter();
 
     private JavascriptFormatter jsFormatter = new JavascriptFormatter();
@@ -459,6 +468,11 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             rc.skippedCount++;
             log.debug("Equal hash code. Not writing result to file.");
             return;
+        }
+
+        if (failIfNotFormatted) {
+            log.debug("Failing the build as one of the files were not properly formatted");
+            throw new MojoFailureException("Failing the build. File " + file.getName() + " required formatting.");
         }
 
         writeStringToFile(formattedCode, file);


### PR DESCRIPTION
Hello!

I'd love to contribute this change to add the ability to fail a build if any file required formatting.
I find this particularly useful to make sure builds fail in cases where a file required formatting.

A good example would be, you might want to add this to Travis CI to fail any builds that don't match the expected formatting.

NOTE: I could not actually build the plugin. `mvn install` didn't work :(
Is there a DEVELOPMENT readme we can create if there are additional steps needed?

https://github.com/revelc/formatter-maven-plugin/issues/158