### PR TITLE
[ci] Catch TextEdit 'IndexOutOfBoundsException' and print debug contents - Fixes #162

### DIFF
--- a/maven-plugin/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2010-2016. All work is copyrighted to their respective
+ * Copyright 2010-2017. All work is copyrighted to their respective
  * author(s), unless otherwise stated.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
@@ -51,11 +51,16 @@ public class JavaFormatter extends AbstractCacheableFormatter implements Formatt
 
     @Override
     public String doFormat(String code, LineEnding ending) throws IOException, BadLocationException {
-        TextEdit te = this.formatter.format(CodeFormatter.K_COMPILATION_UNIT, code, 0, code.length(), 0,
-                ending.getChars());
-        if (te == null) {
-            this.log.debug(
-                    "Code cannot be formatted. Possible cause " + "is unmatched source/target/compliance version.");
+        TextEdit te;
+        try {
+            te = this.formatter.format(CodeFormatter.K_COMPILATION_UNIT, code, 0, code.length(), 0, ending.getChars());
+            if (te == null) {
+                this.log.debug(
+                        "Code cannot be formatted. Possible cause is unmatched source/target/compliance version.");
+                return null;
+            }
+        } catch (IndexOutOfBoundsException e) {
+            this.log.debug("Code cannot be formatted for text -->" + code + "<--", e);
             return null;
         }
 


### PR DESCRIPTION
This fixes #162 

Possibly related to how jmockit does things as the issue was discovered in jmockit class which does impact compilation.  Only found one such issue so far and not seeing exactly why it occurred.  However, this will fix the issue, allow formatting to run to completion, and if user wants output they can put in debug.  I did not do this in error level only because I print the entire file when this occurs which could cause excessive noise.  The main point at least for now is that we could not prevent an abend in this condition and at the moment nothing jumps out at being immediately wrong with class in question.

Unfortunately at the moment I cannot share that class code.  Suffice it to say, tested and works but ultimately doesn't shed like on the real issue here.  I will continue to review this.

I do want to get this released quickly.  That said, I'm thinking we should go ahead and split out the plugin again so we can release it as needed.  The other stuff requires no modifications and is simply too painful to test.  Now I could do this by leaving things as is, but removing the module builds of other pieces and removing tycho just to get this released.  We can explore later how we might want that to really look.  I main concern right now is I have no time to deal with this until at least April and I need a fix well before then.