### PR TITLE
Mark mojos as thread-safe

### DIFF
--- a/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -75,7 +75,7 @@ import net.revelc.code.formatter.model.ConfigReader;
  * @author Matt Blanchette
  * @author marvin.froeder
  */
-@Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = false)
+@Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = false, threadSafe = true)
 public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
 
     private static final String FILE_S = " file(s)";

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/ValidateMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/ValidateMojo.java
@@ -35,7 +35,7 @@ import org.apache.maven.plugins.annotations.Parameter;
  * 
  * @author marvin.froeder
  */
-@Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE, requiresProject = false)
+@Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE, requiresProject = false, threadSafe = true)
 public class ValidateMojo extends FormatterMojo {
 
     @Parameter(defaultValue = "false", property = "aggregator", required = true)


### PR DESCRIPTION
Since the mojos don't change the default instantiation strategy, nor they have static non-final attributes, they are thread safe.
They should be marked so to prevent maven from logging warning when using the plugin on parallel reactor builds.