### PR TITLE
[pom] Move maven prerequisites to correct location as it is only vali…

### DIFF
--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -29,6 +29,10 @@
     <artifactId>formatter-maven-plugin</artifactId>
     <packaging>maven-plugin</packaging>
 
+    <prerequisites>
+        <maven>${maven.min-version}</maven>
+    </prerequisites>
+
     <dependencies>
         <dependency>
             <groupId>com.google.code.gson</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -97,10 +97,6 @@
         </contributor>
     </contributors>
 
-    <prerequisites>
-        <maven>${maven.min-version}</maven>
-    </prerequisites>
-
     <modules>
         <module>formatters</module>
         <module>maven-plugin</module>


### PR DESCRIPTION
…d under plugin*

* we use enforcer overall and maven 3.5.0 now throws warnings about
invalid usage.  This fixes the issue without changing our behaviour.