### PR TITLE
Takari 5 lifecycles as one was causing issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,11 +177,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
                     <version>3.5</version>
-                    <configuration>
-                        <goalPrefix>formatter</goalPrefix>
-                        <!-- see https://issues.apache.org/jira/browse/MNG-5346 -->
-                        <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
-                    </configuration>
                     <executions>
                         <execution>
                             <id>default-descriptor</id>
@@ -209,8 +204,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.7.0</version>
                     <configuration>
-                        <!-- Slightly faster builds, see https://issues.apache.org/jira/browse/MCOMPILER-209 -->
-                        <useIncrementalCompilation>false</useIncrementalCompilation>
+                        <!-- ignore takari-lifecycle -->
+                        <skip>false</skip>
+                        <skipMain>false</skipMain>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -218,6 +214,7 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>2.8.2</version>
                     <configuration>
+                        <!-- ignore takari-lifecycle -->
                         <skip>false</skip>
                     </configuration>
                 </plugin>
@@ -243,6 +240,7 @@
                     <artifactId>maven-install-plugin</artifactId>
                     <version>2.5.2</version>
                     <configuration>
+                        <!-- ignore takari-lifecycle -->
                         <skip>false</skip>
                     </configuration>
                 </plugin>
@@ -250,6 +248,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.0.2</version>
+                    <configuration>
+                        <!-- ignore takari-lifecycle -->
+                        <skip>false</skip>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -287,6 +289,10 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
                     <version>3.0.2</version>
+                    <configuration>
+                        <!-- ignore takari-lifecycle -->
+                        <skip>false</skip>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
We were not actually building correctly at all since July.  This was unusable code best I can determine.  We don't use takari ourselves but tycho is and it's enforcing upon us.  Turned it off and added additional comments which align with 5 plugins it wants to replace.  The code is now usable again.