### PR TITLE
Use eclipses jdt-core directly and disable progard for jsdt core as not fully implemented

### DIFF
--- a/formatters/pom.xml
+++ b/formatters/pom.xml
@@ -30,7 +30,8 @@
     <packaging>pom</packaging>
 
     <modules>
-        <module>jdt-core</module>
+        <!-- No longer necessary -->
+        <!-- <module>jdt-core</module> -->
         <module>jsdt-core</module>
     </modules>
 

--- a/formatters/pom.xml
+++ b/formatters/pom.xml
@@ -61,6 +61,8 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <!-- Unnecessary inclusion never actually used -->
+                    <!-- 
                     <plugin>
                         <groupId>com.github.wvengen</groupId>
                         <artifactId>proguard-maven-plugin</artifactId>
@@ -85,6 +87,7 @@
                             </execution>
                         </executions>
                     </plugin>
+                    -->
                 </plugins>
             </build>
         </profile>

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -46,11 +46,6 @@
         </dependency>
         <dependency>
             <groupId>net.revelc.code.formatter</groupId>
-            <artifactId>jdt-core</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>net.revelc.code.formatter</groupId>
             <artifactId>jsdt-core</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -83,6 +78,11 @@
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
             <version>3.1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jdt</groupId>
+            <artifactId>org.eclipse.jdt.core</artifactId>
+            <version>3.12.3</version>
         </dependency>
         <dependency>
             <groupId>org.jsoup</groupId>


### PR DESCRIPTION
Use the official jdt-core from eclipse.  For eclipse Neon which we are targetting that is 3.12.3.

Progard intentions were good but it wasn't actually used by the plugin at all nor was it complete.  Various attemps to adjust it ran into issues with illegal access presumably because it might have been mixing up classes to some degree.  If thee is a strong need for this, it is gone with moving to the official jdt-core because it was for size savings and we clearly would be giving that up.  However, if really needed, why not use felix plugin instead since it's more osgi like to start with.

This PR is more for review than anything but can be merged.  A follow-up would officially remove all the pieces we are intended to get rid of.  The ending structure would stay the same in case we need to pull anything else in from eclipse or elsewhere.