### PR TITLE
Fix #244 Correct/Improve license documentation

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,14 +1,4 @@
-Copyright 2010-2016. All work is copyrighted to their respective
-author(s), unless otherwise stated.
+Copyright 2010-2017. This project contains code from a community of
+contributors at https://github.com/revelc/formatter-maven-plugin
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-     http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+All work is copyrighted to their respective author(s), unless otherwise stated.

--- a/copyright.txt
+++ b/copyright.txt
@@ -1,6 +1,3 @@
-Copyright ${license.git.copyrightYears}. All work is copyrighted to their respective
-author(s), unless otherwise stated.
-
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/m2e-configurator/catalog.xml
+++ b/m2e-configurator/catalog.xml
@@ -1,8 +1,5 @@
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
@@ -25,7 +22,7 @@
       <groupId>lifecycles</groupId>
       <id>net.revelc.code.formatter.connector</id>
       <kind>lifecycles</kind>
-      <license>EPL</license>
+      <license>ASL 2.0</license>
       <name>formatter</name>
       <provider>code.revelc.net</provider>
       <p2>

--- a/m2e-configurator/net.revelc.code.formatter.feature/build.properties
+++ b/m2e-configurator/net.revelc.code.formatter.feature/build.properties
@@ -1,7 +1,4 @@
 #
-# Copyright 2010-2016. All work is copyrighted to their respective
-# author(s), unless otherwise stated.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.feature/feature.properties
+++ b/m2e-configurator/net.revelc.code.formatter.feature/feature.properties
@@ -1,5 +1,5 @@
 #
-# Copyright 2010-2016. All work is copyrighted to their respective
+# Copyright 2010-2017. All work is copyrighted to their respective
 # author(s), unless otherwise stated.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -35,14 +35,10 @@ description=m2e connector for formatter-maven-plugin
 
 # "copyright" property - text of the "Feature Update Copyright"
 copyright=\
-Copyright (c) 2008-2016 code.revelc.net\n\
-All rights reserved. This program and the accompanying materials\n\
-are made available under the terms of the Eclipse Public License v1.0\n\
-which accompanies this distribution, and is available at\n\
-http://www.eclipse.org/legal/epl-v10.html\n\
+Copyright 2010-2017. This project contains code from a community of\n\
+contributors at https://github.com/revelc/formatter-maven-plugin\n\
 \n\
-Contributors:\n\
-     code.revelc.net - initial API and implementation\n
+All work is copyrighted to their respective author(s), unless otherwise stated.\n
 ################ end of copyright property ####################################
 
 # "licenseURL" property - URL of the "Feature License"
@@ -53,227 +49,206 @@ licenseURL=license.html
 # should be plain text version of license agreement pointed to be "licenseURL"
 license=\
 \n\
-    Eclipse Public License - v 1.0\n\
+                                 Apache License\n\
+                           Version 2.0, January 2004\n\
+                        http://www.apache.org/licenses/\n\
 \n\
-THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE\n\
-PUBLIC LICENSE ("AGREEMENT"). ANY USE, REPRODUCTION OR DISTRIBUTION OF\n\
-THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS AGREEMENT.\n\
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION\n\
 \n\
-*1. DEFINITIONS*\n\
+   1. Definitions.\n\
 \n\
-"Contribution" means:\n\
+      "License" shall mean the terms and conditions for use, reproduction,\n\
+      and distribution as defined by Sections 1 through 9 of this document.\n\
 \n\
-a) in the case of the initial Contributor, the initial code and\n\
-documentation distributed under this Agreement, and\n\
+      "Licensor" shall mean the copyright owner or entity authorized by\n\
+      the copyright owner that is granting the License.\n\
 \n\
-b) in the case of each subsequent Contributor:\n\
+      "Legal Entity" shall mean the union of the acting entity and all\n\
+      other entities that control, are controlled by, or are under common\n\
+      control with that entity. For the purposes of this definition,\n\
+      "control" means (i) the power, direct or indirect, to cause the\n\
+      direction or management of such entity, whether by contract or\n\
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the\n\
+      outstanding shares, or (iii) beneficial ownership of such entity.\n\
 \n\
-i) changes to the Program, and\n\
+      "You" (or "Your") shall mean an individual or Legal Entity\n\
+      exercising permissions granted by this License.\n\
 \n\
-ii) additions to the Program;\n\
+      "Source" form shall mean the preferred form for making modifications,\n\
+      including but not limited to software source code, documentation\n\
+      source, and configuration files.\n\
 \n\
-where such changes and/or additions to the Program originate from and\n\
-are distributed by that particular Contributor. A Contribution\n\
-'originates' from a Contributor if it was added to the Program by such\n\
-Contributor itself or anyone acting on such Contributor's behalf.\n\
-Contributions do not include additions to the Program which: (i) are\n\
-separate modules of software distributed in conjunction with the Program\n\
-under their own license agreement, and (ii) are not derivative works of\n\
-the Program.\n\
+      "Object" form shall mean any form resulting from mechanical\n\
+      transformation or translation of a Source form, including but\n\
+      not limited to compiled object code, generated documentation,\n\
+      and conversions to other media types.\n\
 \n\
-"Contributor" means any person or entity that distributes the Program.\n\
+      "Work" shall mean the work of authorship, whether in Source or\n\
+      Object form, made available under the License, as indicated by a\n\
+      copyright notice that is included in or attached to the work\n\
+      (an example is provided in the Appendix below).\n\
 \n\
-"Licensed Patents" mean patent claims licensable by a Contributor which\n\
-are necessarily infringed by the use or sale of its Contribution alone\n\
-or when combined with the Program.\n\
+      "Derivative Works" shall mean any work, whether in Source or Object\n\
+      form, that is based on (or derived from) the Work and for which the\n\
+      editorial revisions, annotations, elaborations, or other modifications\n\
+      represent, as a whole, an original work of authorship. For the purposes\n\
+      of this License, Derivative Works shall not include works that remain\n\
+      separable from, or merely link (or bind by name) to the interfaces of,\n\
+      the Work and Derivative Works thereof.\n\
 \n\
-"Program" means the Contributions distributed in accordance with this\n\
-Agreement.\n\
+      "Contribution" shall mean any work of authorship, including\n\
+      the original version of the Work and any modifications or additions\n\
+      to that Work or Derivative Works thereof, that is intentionally\n\
+      submitted to Licensor for inclusion in the Work by the copyright owner\n\
+      or by an individual or Legal Entity authorized to submit on behalf of\n\
+      the copyright owner. For the purposes of this definition, "submitted"\n\
+      means any form of electronic, verbal, or written communication sent\n\
+      to the Licensor or its representatives, including but not limited to\n\
+      communication on electronic mailing lists, source code control systems,\n\
+      and issue tracking systems that are managed by, or on behalf of, the\n\
+      Licensor for the purpose of discussing and improving the Work, but\n\
+      excluding communication that is conspicuously marked or otherwise\n\
+      designated in writing by the copyright owner as "Not a Contribution."\n\
 \n\
-"Recipient" means anyone who receives the Program under this Agreement,\n\
-including all Contributors.\n\
+      "Contributor" shall mean Licensor and any individual or Legal Entity\n\
+      on behalf of whom a Contribution has been received by Licensor and\n\
+      subsequently incorporated within the Work.\n\
 \n\
-*2. GRANT OF RIGHTS*\n\
+   2. Grant of Copyright License. Subject to the terms and conditions of\n\
+      this License, each Contributor hereby grants to You a perpetual,\n\
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n\
+      copyright license to reproduce, prepare Derivative Works of,\n\
+      publicly display, publicly perform, sublicense, and distribute the\n\
+      Work and such Derivative Works in Source or Object form.\n\
 \n\
-a) Subject to the terms of this Agreement, each Contributor hereby\n\
-grants Recipient a non-exclusive, worldwide, royalty-free copyright\n\
-license to reproduce, prepare derivative works of, publicly display,\n\
-publicly perform, distribute and sublicense the Contribution of such\n\
-Contributor, if any, and such derivative works, in source code and\n\
-object code form.\n\
+   3. Grant of Patent License. Subject to the terms and conditions of\n\
+      this License, each Contributor hereby grants to You a perpetual,\n\
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable\n\
+      (except as stated in this section) patent license to make, have made,\n\
+      use, offer to sell, sell, import, and otherwise transfer the Work,\n\
+      where such license applies only to those patent claims licensable\n\
+      by such Contributor that are necessarily infringed by their\n\
+      Contribution(s) alone or by combination of their Contribution(s)\n\
+      with the Work to which such Contribution(s) was submitted. If You\n\
+      institute patent litigation against any entity (including a\n\
+      cross-claim or counterclaim in a lawsuit) alleging that the Work\n\
+      or a Contribution incorporated within the Work constitutes direct\n\
+      or contributory patent infringement, then any patent licenses\n\
+      granted to You under this License for that Work shall terminate\n\
+      as of the date such litigation is filed.\n\
 \n\
-b) Subject to the terms of this Agreement, each Contributor hereby\n\
-grants Recipient a non-exclusive, worldwide, royalty-free patent license\n\
-under Licensed Patents to make, use, sell, offer to sell, import and\n\
-otherwise transfer the Contribution of such Contributor, if any, in\n\
-source code and object code form. This patent license shall apply to the\n\
-combination of the Contribution and the Program if, at the time the\n\
-Contribution is added by the Contributor, such addition of the\n\
-Contribution causes such combination to be covered by the Licensed\n\
-Patents. The patent license shall not apply to any other combinations\n\
-which include the Contribution. No hardware per se is licensed hereunder.\n\
+   4. Redistribution. You may reproduce and distribute copies of the\n\
+      Work or Derivative Works thereof in any medium, with or without\n\
+      modifications, and in Source or Object form, provided that You\n\
+      meet the following conditions:\n\
 \n\
-c) Recipient understands that although each Contributor grants the\n\
-licenses to its Contributions set forth herein, no assurances are\n\
-provided by any Contributor that the Program does not infringe the\n\
-patent or other intellectual property rights of any other entity. Each\n\
-Contributor disclaims any liability to Recipient for claims brought by\n\
-any other entity based on infringement of intellectual property rights\n\
-or otherwise. As a condition to exercising the rights and licenses\n\
-granted hereunder, each Recipient hereby assumes sole responsibility to\n\
-secure any other intellectual property rights needed, if any. For\n\
-example, if a third party patent license is required to allow Recipient\n\
-to distribute the Program, it is Recipient's responsibility to acquire\n\
-that license before distributing the Program.\n\
+      (a) You must give any other recipients of the Work or\n\
+          Derivative Works a copy of this License; and\n\
 \n\
-d) Each Contributor represents that to its knowledge it has sufficient\n\
-copyright rights in its Contribution, if any, to grant the copyright\n\
-license set forth in this Agreement.\n\
+      (b) You must cause any modified files to carry prominent notices\n\
+          stating that You changed the files; and\n\
 \n\
-*3. REQUIREMENTS*\n\
+      (c) You must retain, in the Source form of any Derivative Works\n\
+          that You distribute, all copyright, patent, trademark, and\n\
+          attribution notices from the Source form of the Work,\n\
+          excluding those notices that do not pertain to any part of\n\
+          the Derivative Works; and\n\
 \n\
-A Contributor may choose to distribute the Program in object code form\n\
-under its own license agreement, provided that:\n\
+      (d) If the Work includes a "NOTICE" text file as part of its\n\
+          distribution, then any Derivative Works that You distribute must\n\
+          include a readable copy of the attribution notices contained\n\
+          within such NOTICE file, excluding those notices that do not\n\
+          pertain to any part of the Derivative Works, in at least one\n\
+          of the following places: within a NOTICE text file distributed\n\
+          as part of the Derivative Works; within the Source form or\n\
+          documentation, if provided along with the Derivative Works; or,\n\
+          within a display generated by the Derivative Works, if and\n\
+          wherever such third-party notices normally appear. The contents\n\
+          of the NOTICE file are for informational purposes only and\n\
+          do not modify the License. You may add Your own attribution\n\
+          notices within Derivative Works that You distribute, alongside\n\
+          or as an addendum to the NOTICE text from the Work, provided\n\
+          that such additional attribution notices cannot be construed\n\
+          as modifying the License.\n\
 \n\
-a) it complies with the terms and conditions of this Agreement; and\n\
+      You may add Your own copyright statement to Your modifications and\n\
+      may provide additional or different license terms and conditions\n\
+      for use, reproduction, or distribution of Your modifications, or\n\
+      for any such Derivative Works as a whole, provided Your use,\n\
+      reproduction, and distribution of the Work otherwise complies with\n\
+      the conditions stated in this License.\n\
 \n\
-b) its license agreement:\n\
+   5. Submission of Contributions. Unless You explicitly state otherwise,\n\
+      any Contribution intentionally submitted for inclusion in the Work\n\
+      by You to the Licensor shall be under the terms and conditions of\n\
+      this License, without any additional terms or conditions.\n\
+      Notwithstanding the above, nothing herein shall supersede or modify\n\
+      the terms of any separate license agreement you may have executed\n\
+      with Licensor regarding such Contributions.\n\
 \n\
-i) effectively disclaims on behalf of all Contributors all warranties\n\
-and conditions, express and implied, including warranties or conditions\n\
-of title and non-infringement, and implied warranties or conditions of\n\
-merchantability and fitness for a particular purpose;\n\
+   6. Trademarks. This License does not grant permission to use the trade\n\
+      names, trademarks, service marks, or product names of the Licensor,\n\
+      except as required for reasonable and customary use in describing the\n\
+      origin of the Work and reproducing the content of the NOTICE file.\n\
 \n\
-ii) effectively excludes on behalf of all Contributors all liability for\n\
-damages, including direct, indirect, special, incidental and\n\
-consequential damages, such as lost profits;\n\
+   7. Disclaimer of Warranty. Unless required by applicable law or\n\
+      agreed to in writing, Licensor provides the Work (and each\n\
+      Contributor provides its Contributions) on an "AS IS" BASIS,\n\
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or\n\
+      implied, including, without limitation, any warranties or conditions\n\
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A\n\
+      PARTICULAR PURPOSE. You are solely responsible for determining the\n\
+      appropriateness of using or redistributing the Work and assume any\n\
+      risks associated with Your exercise of permissions under this License.\n\
 \n\
-iii) states that any provisions which differ from this Agreement are\n\
-offered by that Contributor alone and not by any other party; and\n\
+   8. Limitation of Liability. In no event and under no legal theory,\n\
+      whether in tort (including negligence), contract, or otherwise,\n\
+      unless required by applicable law (such as deliberate and grossly\n\
+      negligent acts) or agreed to in writing, shall any Contributor be\n\
+      liable to You for damages, including any direct, indirect, special,\n\
+      incidental, or consequential damages of any character arising as a\n\
+      result of this License or out of the use or inability to use the\n\
+      Work (including but not limited to damages for loss of goodwill,\n\
+      work stoppage, computer failure or malfunction, or any and all\n\
+      other commercial damages or losses), even if such Contributor\n\
+      has been advised of the possibility of such damages.\n\
 \n\
-iv) states that source code for the Program is available from such\n\
-Contributor, and informs licensees how to obtain it in a reasonable\n\
-manner on or through a medium customarily used for software exchange.\n\
+   9. Accepting Warranty or Additional Liability. While redistributing\n\
+      the Work or Derivative Works thereof, You may choose to offer,\n\
+      and charge a fee for, acceptance of support, warranty, indemnity,\n\
+      or other liability obligations and/or rights consistent with this\n\
+      License. However, in accepting such obligations, You may act only\n\
+      on Your own behalf and on Your sole responsibility, not on behalf\n\
+      of any other Contributor, and only if You agree to indemnify,\n\
+      defend, and hold each Contributor harmless for any liability\n\
+      incurred by, or claims asserted against, such Contributor by reason\n\
+      of your accepting any such warranty or additional liability.\n\
 \n\
-When the Program is made available in source code form:\n\
+   END OF TERMS AND CONDITIONS\n\
 \n\
-a) it must be made available under this Agreement; and\n\
+   APPENDIX: How to apply the Apache License to your work.\n\
 \n\
-b) a copy of this Agreement must be included with each copy of the Program.\n\
+      To apply the Apache License to your work, attach the following\n\
+      boilerplate notice, with the fields enclosed by brackets "[]"\n\
+      replaced with your own identifying information. (Don't include\n\
+      the brackets!)  The text should be enclosed in the appropriate\n\
+      comment syntax for the file format. We also recommend that a\n\
+      file or class name and description of purpose be included on the\n\
+      same "printed page" as the copyright notice for easier\n\
+      identification within third-party archives.\n\
 \n\
-Contributors may not remove or alter any copyright notices contained\n\
-within the Program.\n\
+   Copyright [yyyy] [name of copyright owner]\n\
 \n\
-Each Contributor must identify itself as the originator of its\n\
-Contribution, if any, in a manner that reasonably allows subsequent\n\
-Recipients to identify the originator of the Contribution.\n\
+   Licensed under the Apache License, Version 2.0 (the "License");\n\
+   you may not use this file except in compliance with the License.\n\
+   You may obtain a copy of the License at\n\
 \n\
-*4. COMMERCIAL DISTRIBUTION*\n\
+       http://www.apache.org/licenses/LICENSE-2.0\n\
 \n\
-Commercial distributors of software may accept certain responsibilities\n\
-with respect to end users, business partners and the like. While this\n\
-license is intended to facilitate the commercial use of the Program, the\n\
-Contributor who includes the Program in a commercial product offering\n\
-should do so in a manner which does not create potential liability for\n\
-other Contributors. Therefore, if a Contributor includes the Program in\n\
-a commercial product offering, such Contributor ("Commercial\n\
-Contributor") hereby agrees to defend and indemnify every other\n\
-Contributor ("Indemnified Contributor") against any losses, damages and\n\
-costs (collectively "Losses") arising from claims, lawsuits and other\n\
-legal actions brought by a third party against the Indemnified\n\
-Contributor to the extent caused by the acts or omissions of such\n\
-Commercial Contributor in connection with its distribution of the\n\
-Program in a commercial product offering. The obligations in this\n\
-section do not apply to any claims or Losses relating to any actual or\n\
-alleged intellectual property infringement. In order to qualify, an\n\
-Indemnified Contributor must: a) promptly notify the Commercial\n\
-Contributor in writing of such claim, and b) allow the Commercial\n\
-Contributor to control, and cooperate with the Commercial Contributor\n\
-in, the defense and any related settlement negotiations. The Indemnified\n\
-Contributor may participate in any such claim at its own expense.\n\
-\n\
-For example, a Contributor might include the Program in a commercial\n\
-product offering, Product X. That Contributor is then a Commercial\n\
-Contributor. If that Commercial Contributor then makes performance\n\
-claims, or offers warranties related to Product X, those performance\n\
-claims and warranties are such Commercial Contributor's responsibility\n\
-alone. Under this section, the Commercial Contributor would have to\n\
-defend claims against the other Contributors related to those\n\
-performance claims and warranties, and if a court requires any other\n\
-Contributor to pay any damages as a result, the Commercial Contributor\n\
-must pay those damages.\n\
-\n\
-*5. NO WARRANTY*\n\
-\n\
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS PROVIDED\n\
-ON AN "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,\n\
-EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES\n\
-OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY OR FITNESS FOR\n\
-A PARTICULAR PURPOSE. Each Recipient is solely responsible for\n\
-determining the appropriateness of using and distributing the Program\n\
-and assumes all risks associated with its exercise of rights under this\n\
-Agreement , including but not limited to the risks and costs of program\n\
-errors, compliance with applicable laws, damage to or loss of data,\n\
-programs or equipment, and unavailability or interruption of operations.\n\
-\n\
-*6. DISCLAIMER OF LIABILITY*\n\
-\n\
-EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT NOR\n\
-ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,\n\
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING\n\
-WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF\n\
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING\n\
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR\n\
-DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED\n\
-HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.\n\
-\n\
-*7. GENERAL*\n\
-\n\
-If any provision of this Agreement is invalid or unenforceable under\n\
-applicable law, it shall not affect the validity or enforceability of\n\
-the remainder of the terms of this Agreement, and without further action\n\
-by the parties hereto, such provision shall be reformed to the minimum\n\
-extent necessary to make such provision valid and enforceable.\n\
-\n\
-If Recipient institutes patent litigation against any entity (including\n\
-a cross-claim or counterclaim in a lawsuit) alleging that the Program\n\
-itself (excluding combinations of the Program with other software or\n\
-hardware) infringes such Recipient's patent(s), then such Recipient's\n\
-rights granted under Section 2(b) shall terminate as of the date such\n\
-litigation is filed.\n\
-\n\
-All Recipient's rights under this Agreement shall terminate if it fails\n\
-to comply with any of the material terms or conditions of this Agreement\n\
-and does not cure such failure in a reasonable period of time after\n\
-becoming aware of such noncompliance. If all Recipient's rights under\n\
-this Agreement terminate, Recipient agrees to cease use and distribution\n\
-of the Program as soon as reasonably practicable. However, Recipient's\n\
-obligations under this Agreement and any licenses granted by Recipient\n\
-relating to the Program shall continue and survive.\n\
-\n\
-Everyone is permitted to copy and distribute copies of this Agreement,\n\
-but in order to avoid inconsistency the Agreement is copyrighted and may\n\
-only be modified in the following manner. The Agreement Steward reserves\n\
-the right to publish new versions (including revisions) of this\n\
-Agreement from time to time. No one other than the Agreement Steward has\n\
-the right to modify this Agreement. The Eclipse Foundation is the\n\
-initial Agreement Steward. The Eclipse Foundation may assign the\n\
-responsibility to serve as the Agreement Steward to a suitable separate\n\
-entity. Each new version of the Agreement will be given a distinguishing\n\
-version number. The Program (including Contributions) may always be\n\
-distributed subject to the version of the Agreement under which it was\n\
-received. In addition, after a new version of the Agreement is\n\
-published, Contributor may elect to distribute the Program (including\n\
-its Contributions) under the new version. Except as expressly stated in\n\
-Sections 2(a) and 2(b) above, Recipient receives no rights or licenses\n\
-to the intellectual property of any Contributor under this Agreement,\n\
-whether expressly, by implication, estoppel or otherwise. All rights in\n\
-the Program not expressly granted under this Agreement are reserved.\n\
-\n\
-This Agreement is governed by the laws of the State of New York and the\n\
-intellectual property laws of the United States of America. No party to\n\
-this Agreement will bring a legal action under this Agreement more than\n\
-one year after the cause of action arose. Each party waives its rights\n\
-to a jury trial in any resulting litigation.\n\
+   Unless required by applicable law or agreed to in writing, software\n\
+   distributed under the License is distributed on an "AS IS" BASIS,\n\
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.\n\
+   See the License for the specific language governing permissions and\n\
+   limitations under the License.\n\
 \n
 ########### end of license property ##########################################

--- a/m2e-configurator/net.revelc.code.formatter.feature/feature.xml
+++ b/m2e-configurator/net.revelc.code.formatter.feature/feature.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.feature/license.html
+++ b/m2e-configurator/net.revelc.code.formatter.feature/license.html
@@ -1,261 +1,192 @@
-<?xml version="1.0" encoding="ISO-8859-1" ?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
-
+<!DOCTYPE html>
+<html lang="en">
 <head>
-<meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
-<title>Eclipse Public License - Version 1.0</title>
-<style type="text/css">
-  body {
-    size: 8.5in 11.0in;
-    margin: 0.25in 0.5in 0.25in 0.5in;
-    tab-interval: 0.5in;
-    }
-  p {  	
-    margin-left: auto;
-    margin-top:  0.5em;
-    margin-bottom: 0.5em;
-    }
-  p.list {
-  	margin-left: 0.5in;
-    margin-top:  0.05em;
-    margin-bottom: 0.05em;
-    }
-  </style>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>Apache License, Version 2.0</title>
 
 </head>
 
-<body lang="EN-US">
-
-<h2>Eclipse Public License - v 1.0</h2>
-
-<p>THE ACCOMPANYING PROGRAM IS PROVIDED UNDER THE TERMS OF THIS ECLIPSE
-PUBLIC LICENSE (&quot;AGREEMENT&quot;). ANY USE, REPRODUCTION OR
-DISTRIBUTION OF THE PROGRAM CONSTITUTES RECIPIENT'S ACCEPTANCE OF THIS
-AGREEMENT.</p>
-
-<p><b>1. DEFINITIONS</b></p>
-
-<p>&quot;Contribution&quot; means:</p>
-
-<p class="list">a) in the case of the initial Contributor, the initial
-code and documentation distributed under this Agreement, and</p>
-<p class="list">b) in the case of each subsequent Contributor:</p>
-<p class="list">i) changes to the Program, and</p>
-<p class="list">ii) additions to the Program;</p>
-<p class="list">where such changes and/or additions to the Program
-originate from and are distributed by that particular Contributor. A
-Contribution 'originates' from a Contributor if it was added to the
-Program by such Contributor itself or anyone acting on such
-Contributor's behalf. Contributions do not include additions to the
-Program which: (i) are separate modules of software distributed in
-conjunction with the Program under their own license agreement, and (ii)
-are not derivative works of the Program.</p>
-
-<p>&quot;Contributor&quot; means any person or entity that distributes
-the Program.</p>
-
-<p>&quot;Licensed Patents&quot; mean patent claims licensable by a
-Contributor which are necessarily infringed by the use or sale of its
-Contribution alone or when combined with the Program.</p>
-
-<p>&quot;Program&quot; means the Contributions distributed in accordance
-with this Agreement.</p>
-
-<p>&quot;Recipient&quot; means anyone who receives the Program under
-this Agreement, including all Contributors.</p>
-
-<p><b>2. GRANT OF RIGHTS</b></p>
-
-<p class="list">a) Subject to the terms of this Agreement, each
-Contributor hereby grants Recipient a non-exclusive, worldwide,
-royalty-free copyright license to reproduce, prepare derivative works
-of, publicly display, publicly perform, distribute and sublicense the
-Contribution of such Contributor, if any, and such derivative works, in
-source code and object code form.</p>
-
-<p class="list">b) Subject to the terms of this Agreement, each
-Contributor hereby grants Recipient a non-exclusive, worldwide,
-royalty-free patent license under Licensed Patents to make, use, sell,
-offer to sell, import and otherwise transfer the Contribution of such
-Contributor, if any, in source code and object code form. This patent
-license shall apply to the combination of the Contribution and the
-Program if, at the time the Contribution is added by the Contributor,
-such addition of the Contribution causes such combination to be covered
-by the Licensed Patents. The patent license shall not apply to any other
-combinations which include the Contribution. No hardware per se is
-licensed hereunder.</p>
-
-<p class="list">c) Recipient understands that although each Contributor
-grants the licenses to its Contributions set forth herein, no assurances
-are provided by any Contributor that the Program does not infringe the
-patent or other intellectual property rights of any other entity. Each
-Contributor disclaims any liability to Recipient for claims brought by
-any other entity based on infringement of intellectual property rights
-or otherwise. As a condition to exercising the rights and licenses
-granted hereunder, each Recipient hereby assumes sole responsibility to
-secure any other intellectual property rights needed, if any. For
-example, if a third party patent license is required to allow Recipient
-to distribute the Program, it is Recipient's responsibility to acquire
-that license before distributing the Program.</p>
-
-<p class="list">d) Each Contributor represents that to its knowledge it
-has sufficient copyright rights in its Contribution, if any, to grant
-the copyright license set forth in this Agreement.</p>
-
-<p><b>3. REQUIREMENTS</b></p>
-
-<p>A Contributor may choose to distribute the Program in object code
-form under its own license agreement, provided that:</p>
-
-<p class="list">a) it complies with the terms and conditions of this
-Agreement; and</p>
-
-<p class="list">b) its license agreement:</p>
-
-<p class="list">i) effectively disclaims on behalf of all Contributors
-all warranties and conditions, express and implied, including warranties
-or conditions of title and non-infringement, and implied warranties or
-conditions of merchantability and fitness for a particular purpose;</p>
-
-<p class="list">ii) effectively excludes on behalf of all Contributors
-all liability for damages, including direct, indirect, special,
-incidental and consequential damages, such as lost profits;</p>
-
-<p class="list">iii) states that any provisions which differ from this
-Agreement are offered by that Contributor alone and not by any other
-party; and</p>
-
-<p class="list">iv) states that source code for the Program is available
-from such Contributor, and informs licensees how to obtain it in a
-reasonable manner on or through a medium customarily used for software
-exchange.</p>
-
-<p>When the Program is made available in source code form:</p>
-
-<p class="list">a) it must be made available under this Agreement; and</p>
-
-<p class="list">b) a copy of this Agreement must be included with each
-copy of the Program.</p>
-
-<p>Contributors may not remove or alter any copyright notices contained
-within the Program.</p>
-
-<p>Each Contributor must identify itself as the originator of its
-Contribution, if any, in a manner that reasonably allows subsequent
-Recipients to identify the originator of the Contribution.</p>
-
-<p><b>4. COMMERCIAL DISTRIBUTION</b></p>
-
-<p>Commercial distributors of software may accept certain
-responsibilities with respect to end users, business partners and the
-like. While this license is intended to facilitate the commercial use of
-the Program, the Contributor who includes the Program in a commercial
-product offering should do so in a manner which does not create
-potential liability for other Contributors. Therefore, if a Contributor
-includes the Program in a commercial product offering, such Contributor
-(&quot;Commercial Contributor&quot;) hereby agrees to defend and
-indemnify every other Contributor (&quot;Indemnified Contributor&quot;)
-against any losses, damages and costs (collectively &quot;Losses&quot;)
-arising from claims, lawsuits and other legal actions brought by a third
-party against the Indemnified Contributor to the extent caused by the
-acts or omissions of such Commercial Contributor in connection with its
-distribution of the Program in a commercial product offering. The
-obligations in this section do not apply to any claims or Losses
-relating to any actual or alleged intellectual property infringement. In
-order to qualify, an Indemnified Contributor must: a) promptly notify
-the Commercial Contributor in writing of such claim, and b) allow the
-Commercial Contributor to control, and cooperate with the Commercial
-Contributor in, the defense and any related settlement negotiations. The
-Indemnified Contributor may participate in any such claim at its own
-expense.</p>
-
-<p>For example, a Contributor might include the Program in a commercial
-product offering, Product X. That Contributor is then a Commercial
-Contributor. If that Commercial Contributor then makes performance
-claims, or offers warranties related to Product X, those performance
-claims and warranties are such Commercial Contributor's responsibility
-alone. Under this section, the Commercial Contributor would have to
-defend claims against the other Contributors related to those
-performance claims and warranties, and if a court requires any other
-Contributor to pay any damages as a result, the Commercial Contributor
-must pay those damages.</p>
-
-<p><b>5. NO WARRANTY</b></p>
-
-<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, THE PROGRAM IS
-PROVIDED ON AN &quot;AS IS&quot; BASIS, WITHOUT WARRANTIES OR CONDITIONS
-OF ANY KIND, EITHER EXPRESS OR IMPLIED INCLUDING, WITHOUT LIMITATION,
-ANY WARRANTIES OR CONDITIONS OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY
-OR FITNESS FOR A PARTICULAR PURPOSE. Each Recipient is solely
-responsible for determining the appropriateness of using and
-distributing the Program and assumes all risks associated with its
-exercise of rights under this Agreement , including but not limited to
-the risks and costs of program errors, compliance with applicable laws,
-damage to or loss of data, programs or equipment, and unavailability or
-interruption of operations.</p>
-
-<p><b>6. DISCLAIMER OF LIABILITY</b></p>
-
-<p>EXCEPT AS EXPRESSLY SET FORTH IN THIS AGREEMENT, NEITHER RECIPIENT
-NOR ANY CONTRIBUTORS SHALL HAVE ANY LIABILITY FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING
-WITHOUT LIMITATION LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OR
-DISTRIBUTION OF THE PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED
-HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.</p>
-
-<p><b>7. GENERAL</b></p>
-
-<p>If any provision of this Agreement is invalid or unenforceable under
-applicable law, it shall not affect the validity or enforceability of
-the remainder of the terms of this Agreement, and without further action
-by the parties hereto, such provision shall be reformed to the minimum
-extent necessary to make such provision valid and enforceable.</p>
-
-<p>If Recipient institutes patent litigation against any entity
-(including a cross-claim or counterclaim in a lawsuit) alleging that the
-Program itself (excluding combinations of the Program with other
-software or hardware) infringes such Recipient's patent(s), then such
-Recipient's rights granted under Section 2(b) shall terminate as of the
+<body>
+<div class="container">
+<p>Apache License<br>Version 2.0, January 2004<br>
+<a href="http://www.apache.org/licenses/">http://www.apache.org/licenses/</a> </p>
+<p>TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION</p>
+<p><strong><a id="definitions">1. Definitions</a></strong>.</p>
+<p>"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.</p>
+<p>"Licensor" shall mean the copyright owner or entity authorized by the
+copyright owner that is granting the License.</p>
+<p>"Legal Entity" shall mean the union of the acting entity and all other
+entities that control, are controlled by, or are under common control with
+that entity. For the purposes of this definition, "control" means (i) the
+power, direct or indirect, to cause the direction or management of such
+entity, whether by contract or otherwise, or (ii) ownership of fifty
+percent (50%) or more of the outstanding shares, or (iii) beneficial
+ownership of such entity.</p>
+<p>"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.</p>
+<p>"Source" form shall mean the preferred form for making modifications,
+including but not limited to software source code, documentation source,
+and configuration files.</p>
+<p>"Object" form shall mean any form resulting from mechanical transformation
+or translation of a Source form, including but not limited to compiled
+object code, generated documentation, and conversions to other media types.</p>
+<p>"Work" shall mean the work of authorship, whether in Source or Object form,
+made available under the License, as indicated by a copyright notice that
+is included in or attached to the work (an example is provided in the
+Appendix below).</p>
+<p>"Derivative Works" shall mean any work, whether in Source or Object form,
+that is based on (or derived from) the Work and for which the editorial
+revisions, annotations, elaborations, or other modifications represent, as
+a whole, an original work of authorship. For the purposes of this License,
+Derivative Works shall not include works that remain separable from, or
+merely link (or bind by name) to the interfaces of, the Work and Derivative
+Works thereof.</p>
+<p>"Contribution" shall mean any work of authorship, including the original
+version of the Work and any modifications or additions to that Work or
+Derivative Works thereof, that is intentionally submitted to Licensor for
+inclusion in the Work by the copyright owner or by an individual or Legal
+Entity authorized to submit on behalf of the copyright owner. For the
+purposes of this definition, "submitted" means any form of electronic,
+verbal, or written communication sent to the Licensor or its
+representatives, including but not limited to communication on electronic
+mailing lists, source code control systems, and issue tracking systems that
+are managed by, or on behalf of, the Licensor for the purpose of discussing
+and improving the Work, but excluding communication that is conspicuously
+marked or otherwise designated in writing by the copyright owner as "Not a
+Contribution."</p>
+<p>"Contributor" shall mean Licensor and any individual or Legal Entity on
+behalf of whom a Contribution has been received by Licensor and
+subsequently incorporated within the Work.</p>
+<p><strong><a id="copyright">2. Grant of Copyright License</a></strong>. Subject to the
+terms and conditions of this License, each Contributor hereby grants to You
+a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+copyright license to reproduce, prepare Derivative Works of, publicly
+display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.</p>
+<p><strong><a id="patent">3. Grant of Patent License</a></strong>. Subject to the terms
+and conditions of this License, each Contributor hereby grants to You a
+perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+(except as stated in this section) patent license to make, have made, use,
+offer to sell, sell, import, and otherwise transfer the Work, where such
+license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by
+combination of their Contribution(s) with the Work to which such
+Contribution(s) was submitted. If You institute patent litigation against
+any entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that the Work or a Contribution incorporated within the Work constitutes
+direct or contributory patent infringement, then any patent licenses
+granted to You under this License for that Work shall terminate as of the
 date such litigation is filed.</p>
+<p><strong><a id="redistribution">4. Redistribution</a></strong>. You may reproduce and
+distribute copies of the Work or Derivative Works thereof in any medium,
+with or without modifications, and in Source or Object form, provided that
+You meet the following conditions:</p>
+<ol style="list-style: lower-latin;">
+<li>You must give any other recipients of the Work or Derivative Works a
+copy of this License; and</li>
 
-<p>All Recipient's rights under this Agreement shall terminate if it
-fails to comply with any of the material terms or conditions of this
-Agreement and does not cure such failure in a reasonable period of time
-after becoming aware of such noncompliance. If all Recipient's rights
-under this Agreement terminate, Recipient agrees to cease use and
-distribution of the Program as soon as reasonably practicable. However,
-Recipient's obligations under this Agreement and any licenses granted by
-Recipient relating to the Program shall continue and survive.</p>
+<li>You must cause any modified files to carry prominent notices stating
+that You changed the files; and</li>
 
-<p>Everyone is permitted to copy and distribute copies of this
-Agreement, but in order to avoid inconsistency the Agreement is
-copyrighted and may only be modified in the following manner. The
-Agreement Steward reserves the right to publish new versions (including
-revisions) of this Agreement from time to time. No one other than the
-Agreement Steward has the right to modify this Agreement. The Eclipse
-Foundation is the initial Agreement Steward. The Eclipse Foundation may
-assign the responsibility to serve as the Agreement Steward to a
-suitable separate entity. Each new version of the Agreement will be
-given a distinguishing version number. The Program (including
-Contributions) may always be distributed subject to the version of the
-Agreement under which it was received. In addition, after a new version
-of the Agreement is published, Contributor may elect to distribute the
-Program (including its Contributions) under the new version. Except as
-expressly stated in Sections 2(a) and 2(b) above, Recipient receives no
-rights or licenses to the intellectual property of any Contributor under
-this Agreement, whether expressly, by implication, estoppel or
-otherwise. All rights in the Program not expressly granted under this
-Agreement are reserved.</p>
+<li>You must retain, in the Source form of any Derivative Works that You
+distribute, all copyright, patent, trademark, and attribution notices from
+the Source form of the Work, excluding those notices that do not pertain to
+any part of the Derivative Works; and</li>
 
-<p>This Agreement is governed by the laws of the State of New York and
-the intellectual property laws of the United States of America. No party
-to this Agreement will bring a legal action under this Agreement more
-than one year after the cause of action arose. Each party waives its
-rights to a jury trial in any resulting litigation.</p>
+<li>If the Work includes a "NOTICE" text file as part of its distribution,
+then any Derivative Works that You distribute must include a readable copy
+of the attribution notices contained within such NOTICE file, excluding
+those notices that do not pertain to any part of the Derivative Works, in
+at least one of the following places: within a NOTICE text file distributed
+as part of the Derivative Works; within the Source form or documentation,
+if provided along with the Derivative Works; or, within a display generated
+by the Derivative Works, if and wherever such third-party notices normally
+appear. The contents of the NOTICE file are for informational purposes only
+and do not modify the License. You may add Your own attribution notices
+within Derivative Works that You distribute, alongside or as an addendum to
+the NOTICE text from the Work, provided that such additional attribution
+notices cannot be construed as modifying the License.
+<br/>
+<br/>
+You may add Your own copyright statement to Your modifications and may
+provide additional or different license terms and conditions for use,
+reproduction, or distribution of Your modifications, or for any such
+Derivative Works as a whole, provided Your use, reproduction, and
+distribution of the Work otherwise complies with the conditions stated in
+this License.
+</li>
+
+</ol>
+
+<p><strong><a id="contributions">5. Submission of Contributions</a></strong>. Unless You
+explicitly state otherwise, any Contribution intentionally submitted for
+inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the
+terms of any separate license agreement you may have executed with Licensor
+regarding such Contributions.</p>
+<p><strong><a id="trademarks">6. Trademarks</a></strong>. This License does not grant
+permission to use the trade names, trademarks, service marks, or product
+names of the Licensor, except as required for reasonable and customary use
+in describing the origin of the Work and reproducing the content of the
+NOTICE file.</p>
+<p><strong><a id="no-warranty">7. Disclaimer of Warranty</a></strong>. Unless required by
+applicable law or agreed to in writing, Licensor provides the Work (and
+each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT
+WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including,
+without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You
+are solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise
+of permissions under this License.</p>
+<p><strong><a id="no-liability">8. Limitation of Liability</a></strong>. In no event and
+under no legal theory, whether in tort (including negligence), contract, or
+otherwise, unless required by applicable law (such as deliberate and
+grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special,
+incidental, or consequential damages of any character arising as a result
+of this License or out of the use or inability to use the Work (including
+but not limited to damages for loss of goodwill, work stoppage, computer
+failure or malfunction, or any and all other commercial damages or losses),
+even if such Contributor has been advised of the possibility of such
+damages.</p>
+<p><strong><a id="additional">9. Accepting Warranty or Additional Liability</a></strong>.
+While redistributing the Work or Derivative Works thereof, You may choose
+to offer, and charge a fee for, acceptance of support, warranty, indemnity,
+or other liability obligations and/or rights consistent with this License.
+However, in accepting such obligations, You may act only on Your own behalf
+and on Your sole responsibility, not on behalf of any other Contributor,
+and only if You agree to indemnify, defend, and hold each Contributor
+harmless for any liability incurred by, or claims asserted against, such
+Contributor by reason of your accepting any such warranty or additional
+liability.</p>
+<p>END OF TERMS AND CONDITIONS</p>
+<h1 id="apply">APPENDIX: How to apply the Apache License to your work</h1>
+<p>To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included
+on the same "printed page" as the copyright notice for easier
+identification within third-party archives.</p>
+<div class="codehilite"><pre>Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the &quot;License&quot;);
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an &quot;AS IS&quot; BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+</pre></div></div>
 
 </body>
-
 </html>

--- a/m2e-configurator/net.revelc.code.formatter.feature/pom.xml
+++ b/m2e-configurator/net.revelc.code.formatter.feature/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.feature/src/site/site.xml
+++ b/m2e-configurator/net.revelc.code.formatter.feature/src/site/site.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.site/category.xml
+++ b/m2e-configurator/net.revelc.code.formatter.site/category.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.site/pom.xml
+++ b/m2e-configurator/net.revelc.code.formatter.site/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.site/src/site/site.xml
+++ b/m2e-configurator/net.revelc.code.formatter.site/src/site/site.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/build.properties
+++ b/m2e-configurator/net.revelc.code.formatter.tests/build.properties
@@ -1,7 +1,4 @@
 #
-# Copyright 2010-2016. All work is copyrighted to their respective
-# author(s), unless otherwise stated.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/pom.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/projects/modular-sample/modular-sample-child/pom.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/projects/modular-sample/modular-sample-child/pom.xml
@@ -1,8 +1,5 @@
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/projects/modular-sample/pom.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/projects/modular-sample/pom.xml
@@ -1,8 +1,5 @@
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/projects/modular-sample/src/config/eclipse/formatter/java.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/projects/modular-sample/src/config/eclipse/formatter/java.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/projects/modular-sample/src/config/eclipse/formatter/javascript.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/projects/modular-sample/src/config/eclipse/formatter/javascript.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/projects/simple-sample/pom.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/projects/simple-sample/pom.xml
@@ -1,8 +1,5 @@
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/projects/simple-sample/src/config/eclipse/formatter/java.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/projects/simple-sample/src/config/eclipse/formatter/java.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/projects/simple-sample/src/config/eclipse/formatter/javascript.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/projects/simple-sample/src/config/eclipse/formatter/javascript.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/settings.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/settings.xml
@@ -1,8 +1,5 @@
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/src/site/site.xml
+++ b/m2e-configurator/net.revelc.code.formatter.tests/src/site/site.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter.tests/src/test/net/revelc/code/formatter/tests/BuildhelperTest.java
+++ b/m2e-configurator/net.revelc.code.formatter.tests/src/test/net/revelc/code/formatter/tests/BuildhelperTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter/build.properties
+++ b/m2e-configurator/net.revelc.code.formatter/build.properties
@@ -1,7 +1,4 @@
 #
-# Copyright 2010-2016. All work is copyrighted to their respective
-# author(s), unless otherwise stated.
-#
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter/lifecycle-mapping-metadata.xml
+++ b/m2e-configurator/net.revelc.code.formatter/lifecycle-mapping-metadata.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter/plugin.xml
+++ b/m2e-configurator/net.revelc.code.formatter/plugin.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter/pom.xml
+++ b/m2e-configurator/net.revelc.code.formatter/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/FormatterCore.java
+++ b/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/FormatterCore.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/internal/FormatterProjectConfigurator.java
+++ b/m2e-configurator/net.revelc.code.formatter/src/net/revelc/code/formatter/connector/internal/FormatterProjectConfigurator.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/m2e-configurator/net.revelc.code.formatter/src/site/site.xml
+++ b/m2e-configurator/net.revelc.code.formatter/src/site/site.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/pom.xml
+++ b/m2e-configurator/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/m2e-configurator/src/site/site.xml
+++ b/m2e-configurator/src/site/site.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/maven-plugin/pom.xml
+++ b/maven-plugin/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/AbstractCacheableFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/AbstractCacheableFormatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/ConfigurationSource.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/ConfigurationSource.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/Formatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/Formatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/LineEnding.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/LineEnding.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/Result.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/Result.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/SystemUtil.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/SystemUtil.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/ValidateMojo.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/ValidateMojo.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/html/HTMLFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/html/HTMLFormatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/javascript/JavascriptFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/javascript/JavascriptFormatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/ConfigReadException.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/ConfigReadException.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/ConfigReader.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/ConfigReader.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/Profile.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/Profile.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/Profiles.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/Profiles.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/RuleSet.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/RuleSet.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/model/Setting.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/model/Setting.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2016. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/main/java/net/revelc/code/formatter/xml/XMLFormatter.java
+++ b/maven-plugin/src/main/java/net/revelc/code/formatter/xml/XMLFormatter.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/site/site.xml
+++ b/maven-plugin/src/site/site.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/LineEndingTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/LineEndingTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/css/CssFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/css/CssFormatterTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -35,7 +32,7 @@ public class JavaFormatterTest extends AbstractFormatterTest {
     @Test
     public void testDoFormatFile() throws Exception {
         doTestFormat(new JavaFormatter(), "AnyClass.java",
-                "321e31508fc3a994d5343eea326253b2c219c3d149099ce05b3c15aa3efb427a5ee2d074d22a41997e66c69c047d80c9edadfcc8b98578632a88620bf2b0b121");
+                "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca");
     }
 
     @Test

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/javascript/JavascriptFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/javascript/JavascriptFormatterTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -32,7 +29,7 @@ public class JavascriptFormatterTest extends AbstractFormatterTest {
     @Test
     public void testDoFormatFile() throws Exception {
         doTestFormat(new JavascriptFormatter(), "AnyJS.js",
-                "91e699e0ed0d20c63a5f151035b93b3ed948e807da7ee360bb9df6b3ddff413fcfd0df7d643608d8f936871a01a3498b68e14d47d76594c0741aba3f096949f5");
+                "33020bfa1ecebd935b6d6ba8e482bc14433ad52899ca63bd892fbb85d20e835ad183dba1e0a6203a72fbbb3d859b6f6872e320a8ea2fa93c9b2ca301ae7c6ec8");
     }
 
     @Test

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/model/ConfigReaderTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/model/ConfigReaderTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/java/net/revelc/code/formatter/xml/XMLFormatterTest.java
+++ b/maven-plugin/src/test/java/net/revelc/code/formatter/xml/XMLFormatterTest.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
@@ -35,7 +32,7 @@ public class XMLFormatterTest extends AbstractFormatterTest {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         if (SystemUtil.LINE_SEPARATOR.equals("\n")) {
             doTestFormat(new XMLFormatter(), "someFile.xml",
-                    "5b37e98476e050998ecad303cc4a3feaca45eb6966e3a7248964df2e670403939b153b45292074e926c1c22c8264df204f0c0011d6c31102652b732186868563");
+                    "ecf687f06e4ada957478267eaf9b3f90461ad2520af37e304400c75e48b3b4daa3e0be60145b76061c496a19df1ce1aa064abc91224d79a725e5cefd12367401");
         } else {
             doTestFormat(new XMLFormatter(), "someFile.xml",
                     "98f896736377248255739514b27e5cad99df44e5daa37664dc8eeb79cdeb3ec113f390247c5573e0713258e8a5da69f8e4078cf2535235e437db451803c2971c");

--- a/maven-plugin/src/test/resources/AnyClass.java
+++ b/maven-plugin/src/test/resources/AnyClass.java
@@ -1,7 +1,4 @@
-/**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
+/*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/resources/AnyJS.js
+++ b/maven-plugin/src/test/resources/AnyJS.js
@@ -1,7 +1,4 @@
 /*
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/resources/sample-config.xml
+++ b/maven-plugin/src/test/resources/sample-config.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/maven-plugin/src/test/resources/sample-invalid-config.xml
+++ b/maven-plugin/src/test/resources/sample-invalid-config.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/maven-plugin/src/test/resources/sample-invalid-config2.xml
+++ b/maven-plugin/src/test/resources/sample-invalid-config2.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2016. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/maven-plugin/src/test/resources/someFile.css
+++ b/maven-plugin/src/test/resources/someFile.css
@@ -1,7 +1,4 @@
 /**
- * Copyright 2010-2017. All work is copyrighted to their respective
- * author(s), unless otherwise stated.
- *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at

--- a/maven-plugin/src/test/resources/someFile.xml
+++ b/maven-plugin/src/test/resources/someFile.xml
@@ -1,8 +1,5 @@
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at
@@ -341,16 +338,6 @@
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>3.0</version>
-                    <configuration>
-                        <header>${main.basedir}/copyright.txt</header>
-                        <excludes>
-                            <exclude>**/*target/**</exclude>
-                            <exclude>**/*build.properties</exclude>
-                            <exclude>**/*maven-wrapper.properties</exclude>
-                            <exclude>mvnw</exclude>
-                            <exclude>mvnw.cmd</exclude>
-                        </excludes>
-                    </configuration>
                     <dependencies>
                         <dependency>
                             <groupId>com.mycila</groupId>
@@ -484,10 +471,25 @@
                 <artifactId>license-maven-plugin</artifactId>
                 <executions>
                     <execution>
+                        <id>license-headers</id>
                         <goals>
                             <goal>format</goal>
                         </goals>
                         <phase>compile</phase>
+                        <configuration>
+                            <header>${main.basedir}/copyright.txt</header>
+                            <excludes>
+                                <exclude>**/target/**</exclude>
+                                <exclude>**/build.properties</exclude>
+                                <exclude>**/maven-wrapper.properties</exclude>
+                                <exclude>mvnw</exclude>
+                                <exclude>mvnw.cmd</exclude>
+                                <exclude>NOTICE</exclude>
+                            </excludes>
+                            <mapping>
+                                <java>SLASHSTAR_STYLE</java>
+                            </mapping>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>

--- a/src/config/eclipse/formatter/java.xml
+++ b/src/config/eclipse/formatter/java.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/src/config/eclipse/formatter/javascript.xml
+++ b/src/config/eclipse/formatter/javascript.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,9 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2010-2017. All work is copyrighted to their respective
-    author(s), unless otherwise stated.
-
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.
     You may obtain a copy of the License at


### PR DESCRIPTION
* Document Apache License where appropriate instead of incorrect EPL 1.0
* Fix file comments in java files (use single star comment blocks when
comments are not javadocs)
* Simplify license headers by consolidating copyright notices into the
NOTICE file (recommended for Apache-licensed code), which makes it
easier on those who redistribute to comply with Apache license
requirements; also easier for project maintainers to update copyright
dates
* Update hashes for tests, when where license header changes affected
the formatting