### PR TITLE
Deploy Maven site using the site-maven-plugin

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,5 @@ cache:
     - $HOME/.m2
 install: echo "Skipping pre-fetch of maven dependencies"
 before_script: mvn validate formatter:validate
-script: mvn clean verify javadoc:jar source:jar site:site
+script: mvn clean verify javadoc:jar source:jar site
 after_success: mvn -Ptravis jacoco:merge jacoco:report coveralls:report

--- a/pom.xml
+++ b/pom.xml
@@ -104,11 +104,6 @@
       <id>sonatype-nexus-snapshots</id>
       <url>https://oss.sonatype.org/content/repositories/snapshots</url>
     </snapshotRepository>
-    <site>
-      <id>gh-pages</id>
-      <name>Formatter Maven Plugin GitHub Pages</name>
-      <url>git:ssh://git@github.com/revelc/formatter-maven-plugin.git?gh-pages#</url>
-    </site>
   </distributionManagement>
 
   <properties>
@@ -118,6 +113,9 @@
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.testSource>1.8</maven.compiler.testSource>
     <maven.compiler.testTarget>1.8</maven.compiler.testTarget>
+
+    <!-- skip standard site deployment, because site is deployed using github plugin instead -->
+    <maven.site.deploy.skip>true</maven.site.deploy.skip>
 
     <project.build.resourceEncoding>UTF-8</project.build.resourceEncoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -225,6 +223,11 @@
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
           <version>2.8.0</version>
+        </plugin>
+        <plugin>
+          <groupId>com.github.github</groupId>
+          <artifactId>site-maven-plugin</artifactId>
+          <version>0.12</version>
         </plugin>
         <plugin>
           <groupId>com.mycila</groupId>
@@ -344,22 +347,11 @@
           <artifactId>maven-site-plugin</artifactId>
           <version>3.7.1</version>
           <dependencies>
-            <dependency>
-              <groupId>net.trajano.wagon</groupId>
-              <artifactId>wagon-git</artifactId>
-              <!-- Do not upgrade to 2.0.4 as it does not work -->
-              <version>2.0.3</version>
-            </dependency>
             <!-- For reporting only of versions -->
             <dependency>
               <groupId>org.apache.maven.skins</groupId>
               <artifactId>maven-fluido-skin</artifactId>
               <version>1.7</version>
-            </dependency>
-            <dependency>
-              <groupId>org.apache.maven.wagon</groupId>
-              <artifactId>wagon-ssh</artifactId>
-              <version>3.2.0</version>
             </dependency>
           </dependencies>
         </plugin>
@@ -431,6 +423,24 @@
               <goal>verify</goal>
             </goals>
             <phase>process-resources</phase>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>com.github.github</groupId>
+        <artifactId>site-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>create-github-pages</id>
+            <goals>
+              <goal>site</goal>
+            </goals>
+            <phase>site-deploy</phase>
+            <configuration>
+              <server>github</server>
+              <message>Creating site for ${project.version}</message>
+              <noJekyll>true</noJekyll>
+            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
* Configures GitHub's site-maven-plugin in place of the wagon-git plugin
from github.com/trajano/wagon-git, which does not work well
cross-platform, nor does it handle authentication issues very well, such
as passwordless using ssh-agent or unknown host keys.
* GitHub's site-maven-plugin uses a simple oath token as the
credentials, and is maintained by GitHub, so it's sure to be the best
way to update gh-pages.
* Deployment is the same (mvn clean package site-deploy -DskipTests)