### PR TITLE
Multimodule configuration example - fixed confusing dependency.

### DIFF
--- a/src/site/apt/examples.apt.vm
+++ b/src/site/apt/examples.apt.vm
@@ -282,9 +282,9 @@ multiproject
         </configuration>
         <dependencies>
           <dependency>
-            <groupId>com.github.hazendaz</groupId>
+            <groupId>com.googlecode.example.multiproject</groupId>
             <artifactId>build-tools</artifactId>
-            <version>1.1.2</version>
+            <version>1.0</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
Example was confusing, point to the build-tools module defined by the user in the parent pom.

[Issue 266](https://github.com/revelc/formatter-maven-plugin/issues/266)

If I define a build-tools module in my multiproject-parent, I want it as a dependency for the formatter-maven-plugin. 