### PR TITLE
Fix for issue #279: Allow JSON formatter to omit space before separator

### DIFF
--- a/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
@@ -13,8 +13,10 @@
  */
 package net.revelc.code.formatter.json;
 
+import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
+import com.fasterxml.jackson.core.util.Separators;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Strings;
@@ -41,12 +43,21 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
 
         int indent = Integer.parseInt(options.getOrDefault("indent", "4"));
         String lineEnding = options.getOrDefault("lineending", SystemUtil.LINE_SEPARATOR);
+        boolean spaceBeforeSeparator = Boolean.parseBoolean(options.getOrDefault("spaceBeforeSeparator", "true"));
 
         formatter = new ObjectMapper();
 
         // Setup a pretty printer with an indenter (indenter has 4 spaces in this case)
         DefaultPrettyPrinter.Indenter indenter = new DefaultIndenter(Strings.repeat(" ", indent), lineEnding);
-        DefaultPrettyPrinter printer = new DefaultPrettyPrinter();
+        DefaultPrettyPrinter printer = new DefaultPrettyPrinter() {
+            public DefaultPrettyPrinter withSeparators(Separators separators) {
+                this._separators = separators;
+                this._objectFieldValueSeparatorWithSpaces = (spaceBeforeSeparator ? " " : "")
+                        + separators.getObjectFieldValueSeparator() + " ";
+                return this;
+            }
+        };
+
         printer.indentObjectsWith(indenter);
         printer.indentArraysWith(indenter);
         formatter.setDefaultPrettyPrinter(printer);

--- a/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
@@ -74,15 +74,22 @@ public abstract class AbstractFormatterTest {
     }
 
     protected void doTestFormat(Formatter formatter, String fileUnderTest, String expectedSha512) throws IOException {
+        doTestFormat(null, formatter, fileUnderTest, expectedSha512);
+    }
+
+    protected void doTestFormat(Map<String, String> options, Formatter formatter, String fileUnderTest,
+            String expectedSha512) throws IOException {
+
         File originalSourceFile = new File("src/test/resources/", fileUnderTest);
         File sourceFile = new File("target/testoutput/", fileUnderTest);
 
-        Map<String, String> options = new HashMap<>();
+        if (null == options) {
+            options = new HashMap<>();
+        }
         final File targetDir = new File("target/testoutput");
         targetDir.mkdirs();
 
         Files.copy(originalSourceFile, sourceFile);
-
         formatter.init(options, new TestConfigurationSource(targetDir));
         Result result = formatter.formatFile(sourceFile, LineEnding.CRLF, false);
         Assertions.assertEquals(Result.SUCCESS, result);

--- a/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
@@ -21,6 +21,7 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @author yoshiman
@@ -42,13 +43,31 @@ public class JsonFormatterTest extends AbstractFormatterTest {
     }
 
     @Test
-    public void testIsIntialized() throws Exception {
+    public void testIsInitialized() {
         JsonFormatter jsonFormatter = new JsonFormatter();
         Assertions.assertFalse(jsonFormatter.isInitialized());
         final File targetDir = new File("target/testoutput");
         targetDir.mkdirs();
         jsonFormatter.init(new HashMap<String, String>(), new AbstractFormatterTest.TestConfigurationSource(targetDir));
         Assertions.assertTrue(jsonFormatter.isInitialized());
+    }
+
+    @Test
+    public void testDoFormatFileWithConfig() throws Exception {
+        Map<String, String> jsonFormattingOptions = new HashMap<>();
+        jsonFormattingOptions.put("indent", "2");
+        jsonFormattingOptions.put("spaceBeforeSeparator", "false");
+
+        // Since we set the line endings via options for json, we cannot rely on CRLF inside doTestFormat.
+        // The option will not be available inside json formatter init so it will use whatever the system
+        // default is regardless of requesting it to be CRLF later which is ignored.
+        if (SystemUtil.LINE_SEPARATOR.equals("\n")) {
+            doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
+                    "478edd57b917235d00f16611505060460758e7e0f4b53938941226dca183d09be7e946d9a14dbac492a200592d5a6fa5f463e60fd1c3d3dbf05c08c3c869a36b");
+        } else {
+            doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
+                    "2f894c97a22f1313fc7eb55a1bab5c1e8353c11c65bf979abe40347307f80e0dd745a3ab1caa39450dcd0701ccdb3bc1b0bb3afd80557bae33e4e4e7015b52a2");
+        }
     }
 
 }


### PR DESCRIPTION
Fixed issue #279.
This feature can be toggled using an additional property into `configJsonFile`
```
spaceBeforeSeparator=false  <-- default value is true
indent=4
```
