### PR TITLE
fail fast in case the config file cannot be found

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -689,7 +689,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
     /**
      * Read config file and return the config as {@link Map}.
      *
-     * @return the options from config file or null if not config file found
+     * @return the options from config file
      * @throws MojoExecutionException
      *             the mojo execution exception
      */
@@ -701,8 +701,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         try (InputStream configInput = this.resourceManager.getResourceAsInputStream(newConfigFile)) {
             return new ConfigReader().read(configInput);
         } catch (ResourceNotFoundException e) {
-            getLog().debug("Config file [" + newConfigFile + "] cannot be found", e);
-            return new HashMap<>();
+            throw new MojoExecutionException("Cannot find config file [" + newConfigFile + "]");
         } catch (IOException e) {
             throw new MojoExecutionException("Cannot read config file [" + newConfigFile + "]", e);
         } catch (SAXException e) {


### PR DESCRIPTION
I'd like to propose a change that will eliminate the whole class of build issues - source code formatting with wrong rules in case of missing config file. Had this issue with config file as a url and the lack of Internet connectivity. This issue is mentioned here as well - https://github.com/revelc/formatter-maven-plugin/issues/275