### PR TITLE
[pom] Add commons-beantuils 1.9.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,6 +141,11 @@
       <version>26.0-jre</version>
     </dependency>
     <dependency>
+      <groupId>commons-beanutils</groupId>
+      <artifactId>commons-beanutils</artifactId>
+      <version>1.9.3</version>
+    </dependency>
+    <dependency>
       <groupId>net.revelc.code.formatter</groupId>
       <artifactId>jsdt-core</artifactId>
       <version>2.6.0</version>
@@ -495,6 +500,9 @@
               <ignoredUnusedDeclaredDependencies>
                 <unusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine:jar:${junit.version}</unusedDeclaredDependency>
               </ignoredUnusedDeclaredDependencies>
+              <ignoredDependencies>
+                <ignoredDependency>commons-beanutils:commons-beanutils</ignoredDependency>
+              </ignoredDependencies>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
To overcome vulnerability concerns.  The version of commons-beanutils that is used within formatter-maven-plugin is known vulnerable.