### PR TITLE
Fix #288 Ensure comment indent options are used

### DIFF
--- a/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
@@ -36,7 +36,7 @@ public class JavaFormatter extends AbstractCacheableFormatter implements Formatt
     public void init(Map<String, String> options, ConfigurationSource cfg) {
         super.initCfg(cfg);
 
-        this.formatter = ToolFactory.createCodeFormatter(options);
+        this.formatter = ToolFactory.createCodeFormatter(options, ToolFactory.M_FORMAT_EXISTING);
     }
 
     @Override

--- a/src/main/java/net/revelc/code/formatter/javascript/JavascriptFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/javascript/JavascriptFormatter.java
@@ -36,7 +36,7 @@ public class JavascriptFormatter extends AbstractCacheableFormatter implements F
     public void init(Map<String, String> options, ConfigurationSource cfg) {
         super.initCfg(cfg);
 
-        this.formatter = ToolFactory.createCodeFormatter(options);
+        this.formatter = ToolFactory.createCodeFormatter(options, ToolFactory.M_FORMAT_EXISTING);
     }
 
     @Override


### PR DESCRIPTION
Use ToolFactory.M_FORMAT_EXISTING when creating the code formatters, in
order to ensure that all options which preserve existing comment
indentation (or lack thereof) are respected.

See Javadoc for ToolFactory.M_FORMAT_EXISTING
And also: https://bugs.eclipse.org/bugs/show_bug.cgi?id=415630