### PR TITLE
Update dependencies including Eclipse IDE 2019-03 release 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -350,7 +350,7 @@
               <!-- Do not upgrade to 2.0.4 as it does not work -->
               <version>2.0.3</version>
             </dependency>
-            <!-- For reporting only of versions -->
+            <!-- Fluido is for reporting on version updates only and not used here -->
             <dependency>
               <groupId>org.apache.maven.skins</groupId>
               <artifactId>maven-fluido-skin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -138,7 +138,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>27.0.1-jre</version>
+      <version>27.1-jre</version>
     </dependency>
     <dependency>
       <!-- override vulnerable transitive version from commons-digester3 -->

--- a/pom.xml
+++ b/pom.xml
@@ -371,7 +371,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M2</version>
+          <version>3.0.0-M3</version>
           <configuration>
             <argLine>${utCoverage}</argLine>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -180,7 +180,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.16.0</version>
+      <version>3.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
   </distributionManagement>
 
   <properties>
-    <junit.version>5.3.2</junit.version>
+    <junit.version>5.4.0</junit.version>
 
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>

--- a/pom.xml
+++ b/pom.xml
@@ -175,7 +175,7 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.1.1</version>
+      <version>3.2.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jdt</groupId>


### PR DESCRIPTION
- junit to 5.4.0
- guava to 27.1-jre
- plexus-utils to 3.2.0
- jdt core to 3.17.0
- surefire to 3.0.0-M3
- Update comment regardle fluido for clarity as it used to apply to the dependency after it as well.