### PR TITLE
Updates for Eclipse 2019-09

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: java
 jdk:
   - openjdk11
-  - openjdk8
 cache:
   directories:
     - $HOME/.m2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,8 @@ ver 2.10.0
 - Support Eclipse 2019-06 formatter
 - Update plugins, dependencies
 
+ver 2.11.0
+==========
+- Support Eclipse 2019-09 formatter
+- Update plugins, dependencies
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -17,7 +17,6 @@ skip_tags: true
 clone_depth: 10
 environment:
   matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     - JAVA_HOME: C:\Program Files\Java\jdk11
 branches:
   only:
@@ -32,10 +31,10 @@ install:
   - ps: |
       Add-Type -AssemblyName System.IO.Compression.FileSystem
       if (!(Test-Path -Path "C:\maven" )) {
-        (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.zip', 'C:\maven-bin.zip')
+        (new-object System.Net.WebClient).DownloadFile('http://www.us.apache.org/dist/maven/maven-3/3.6.2/binaries/apache-maven-3.6.2-bin.zip', 'C:\maven-bin.zip')
         [System.IO.Compression.ZipFile]::ExtractToDirectory("C:\maven-bin.zip", "C:\maven")
       }
-  - cmd: SET PATH=C:\maven\apache-maven-3.6.1\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET PATH=C:\maven\apache-maven-3.6.2\bin;%JAVA_HOME%\bin;%PATH%
   - cmd: SET MAVEN_OPTS=-Xmx4g
   - cmd: SET JAVA_OPTS=-Xmx4g
   - cmd: mvn --version

--- a/pom.xml
+++ b/pom.xml
@@ -114,8 +114,9 @@
   </distributionManagement>
 
   <properties>
-    <junit.version>5.5.1</junit.version>
+    <junit.version>5.6.0-M1</junit.version>
 
+    <maven.compiler.release>8</maven.compiler.release>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
 
@@ -133,79 +134,79 @@
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.commands</artifactId>
-        <version>3.9.400</version>
+        <version>3.9.500</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.contenttype</artifactId>
-        <version>3.7.300</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.expressions</artifactId>
-        <version>3.6.400</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.filesystem</artifactId>
-        <version>1.7.400</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.jobs</artifactId>
-        <version>3.10.400</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.resources</artifactId>
-        <version>3.13.400</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.runtime</artifactId>
-        <version>3.15.300</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.app</artifactId>
-        <version>1.4.200</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.common</artifactId>
-        <version>3.10.400</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.preferences</artifactId>
         <version>3.7.400</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.expressions</artifactId>
+        <version>3.6.500</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.filesystem</artifactId>
+        <version>1.7.500</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.jobs</artifactId>
+        <version>3.10.500</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.resources</artifactId>
+        <version>3.13.500</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.runtime</artifactId>
+        <version>3.16.0</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.app</artifactId>
+        <version>1.4.300</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.common</artifactId>
+        <version>3.10.500</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.preferences</artifactId>
+        <version>3.7.500</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.registry</artifactId>
-        <version>3.8.400</version>
+        <version>3.8.500</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.osgi</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.text</artifactId>
-        <version>3.8.200</version>
+        <version>3.9.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -213,17 +214,17 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.9.10</version>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.9.10</version>
+      <version>2.10.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>28.0-jre</version>
+      <version>28.1-jre</version>
     </dependency>
     <dependency>
       <!-- override vulnerable transitive version from commons-digester3 -->
@@ -239,7 +240,7 @@
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>
       <artifactId>xml-formatter</artifactId>
-      <version>0.1.1</version>
+      <version>0.2.0</version>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.cssparser</groupId>
@@ -265,12 +266,12 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>3.2.1</version>
+      <version>3.3.0</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.18.0</version>
+      <version>3.19.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>
@@ -295,7 +296,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>3.6.1</version>
+      <version>3.6.2</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -366,7 +367,7 @@
         <plugin>
           <groupId>net.revelc.code</groupId>
           <artifactId>impsort-maven-plugin</artifactId>
-          <version>1.3.0</version>
+          <version>1.3.1</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -467,7 +468,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-source-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.2.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -619,9 +620,9 @@
               <failOnWarning>true</failOnWarning>
               <ignoredUnusedDeclaredDependencies>
                 <!-- ignore runtime junit test dependency -->
-                <unusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine:jar:${junit.version}</unusedDeclaredDependency>
+                <ignored>org.junit.jupiter:junit-jupiter-engine</ignored>
                 <!-- ignore transitive dependency overridden to avoid vulnerability -->
-                <ignoredDeclaredDependency>commons-beanutils:commons-beanutils</ignoredDeclaredDependency>
+                <ignored>commons-beanutils:commons-beanutils</ignored>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>
@@ -636,7 +637,7 @@
               <version>[3.3.9,)</version>
             </requireMavenVersion>
             <requireJavaVersion>
-              <version>[${maven.compiler.source},)</version>
+              <version>[11,)</version>
             </requireJavaVersion>
           </rules>
         </configuration>
@@ -822,9 +823,6 @@
           <name>m2e.version</name>
         </property>
       </activation>
-      <properties>
-        <maven.compiler.release>8</maven.compiler.release>
-      </properties>
       <build>
         <pluginManagement>
           <plugins>
@@ -898,15 +896,6 @@
           </plugins>
         </pluginManagement>
       </build>
-    </profile>
-    <profile>
-      <id>jdk-release-flag</id>
-      <activation>
-        <jdk>[9,)</jdk>
-      </activation>
-      <properties>
-        <maven.compiler.release>8</maven.compiler.release>
-      </properties>
     </profile>
   </profiles>
 </project>

--- a/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
@@ -52,6 +52,11 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
             private static final long serialVersionUID = 1L;
 
             @Override
+            public DefaultPrettyPrinter createInstance() {
+                return new DefaultPrettyPrinter(this);
+            }
+
+            @Override
             public DefaultPrettyPrinter withSeparators(Separators separators) {
                 this._separators = separators;
                 this._objectFieldValueSeparatorWithSpaces = (spaceBeforeSeparator ? " " : "")


### PR DESCRIPTION
* Require JDK11 for building (still targeting Java 8 as minimum runtime)
* Update jdt.core for Eclipse 2019-09
* Resolve transitive dependency ranges of jdt.core to updated versions
* Update CI tooling for Maven 3.6.2 and JDK11
* Update jackson and fix JsonFormatter to work with new version
* Update other plugins and dependency versions to latest
* Update xml-formatter library to 0.2.0, which provides new options for
  handling xml files without DTD validation or otherwise fail to parse