### PR TITLE
Add tests for the formatter mojo caching of files, one failing

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -167,7 +167,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * @since 0.3
      */
     @Parameter(property = "project.build.sourceEncoding", required = true)
-    private String encoding;
+    String encoding;
 
     /**
      * Sets the line-ending of files after formatting. Valid values are:
@@ -182,7 +182,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * @since 0.2.0
      */
     @Parameter(defaultValue = "AUTO", property = "lineending", required = true)
-    private LineEnding lineEnding;
+    LineEnding lineEnding;
 
     /**
      * File or classpath location of an Eclipse code formatter configuration xml file to use in formatting.
@@ -224,7 +224,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * Whether the java formatting is skipped.
      */
     @Parameter(defaultValue = "false", property = "formatter.java.skip")
-    private Boolean skipJavaFormatting;
+    Boolean skipJavaFormatting;
 
     /**
      * Whether the javascript formatting is skipped.
@@ -268,9 +268,9 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * Use eclipse defaults when set to true for java and javascript.
      */
     @Parameter(defaultValue = "false", property = "formatter.useEclipseDefaults")
-    private Boolean useEclipseDefaults;
+    Boolean useEclipseDefaults;
 
-    private JavaFormatter javaFormatter = new JavaFormatter();
+    JavaFormatter javaFormatter = new JavaFormatter();
 
     private JavascriptFormatter jsFormatter = new JavascriptFormatter();
 
@@ -581,7 +581,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      *            the str
      * @return the string
      */
-    private String sha512hash(String str) {
+    protected String sha512hash(String str) {
         return Hashing.sha512().hashBytes(str.getBytes(getEncoding())).toString();
     }
 
@@ -634,7 +634,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * @throws MojoExecutionException
      *             the mojo execution exception
      */
-    private void createCodeFormatter() throws MojoExecutionException {
+    void createCodeFormatter() throws MojoExecutionException {
         Map<String, String> javaFormattingOptions = getFormattingOptions(this.configFile);
         if (javaFormattingOptions != null) {
             this.javaFormatter.init(javaFormattingOptions, this);
@@ -742,7 +742,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         return map;
     }
 
-    class ResultCollector {
+    static class ResultCollector {
 
         int successCount;
 

--- a/src/test/java/net/revelc/code/formatter/FormatterMojoTest.java
+++ b/src/test/java/net/revelc/code/formatter/FormatterMojoTest.java
@@ -1,0 +1,123 @@
+package net.revelc.code.formatter;
+
+import com.google.common.io.Files;
+import net.revelc.code.formatter.java.JavaFormatter;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.jface.text.BadLocationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Properties;
+
+import static net.revelc.code.formatter.AbstractFormatterTest.TEST_OUTPUT_DIR;
+import static org.junit.jupiter.api.Assertions.*;
+
+class FormatterMojoTest {
+
+    private static final String PREVIOUS_HASH = "_PREVIOUS_HASH_";
+
+    final FormatterMojo mojo = new FormatterMojo();
+    final FormatterMojo.ResultCollector rc = new FormatterMojo.ResultCollector();
+    final Properties cache = new Properties();
+    final File original = new File("src/test/resources/", "AnyClass.java");
+    final File sourceFile = new File(TEST_OUTPUT_DIR, "AnyClass.java");
+    String basedir;
+    String cacheKey;
+
+    @BeforeEach
+    public void setup() throws IOException {
+        basedir = TEST_OUTPUT_DIR.getCanonicalPath();
+        cacheKey = sourceFile.getCanonicalPath().substring(basedir.length());
+        mojo.useEclipseDefaults = true;
+        mojo.encoding = "UTF-8";
+        mojo.skipJavaFormatting = false;
+        mojo.lineEnding = LineEnding.AUTO;
+        mojo.javaFormatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+    }
+
+    /**
+     * Format a known file that changed.
+     * The new hash should be recorded.
+     */
+    @Test
+    public void format_known_dirty_java_file() throws Exception {
+        File testFile = dirtyFile();
+        String filePath = testFile.getAbsolutePath();
+        cache.put(cacheKey, PREVIOUS_HASH);
+
+        mojo.doFormatFile(testFile, rc, cache, basedir, false);
+
+        String cachedHash = (String) cache.get(cacheKey);
+        String expectedHash = mojo.sha512hash(FileUtils.fileRead(testFile));
+        assertEquals(cachedHash, expectedHash);
+    }
+
+    /**
+     * Skip a known file that did not change.
+     * The existing hash should remain the same.
+     */
+    @Test
+    public void skip_known_unchanged_java_file() throws Exception {
+        File testFile = cleanFile();
+        String filePath = testFile.getAbsolutePath();
+        String unchangedHash = mojo.sha512hash(FileUtils.fileRead(filePath));
+        cache.put(cacheKey, unchangedHash);
+
+        mojo.doFormatFile(testFile, rc, cache, basedir, false);
+
+        String cachedHash = (String) cache.get(cacheKey);
+        assertEquals(rc.skippedCount, 1);
+        assertEquals(cachedHash, unchangedHash);
+    }
+
+    /**
+     * Format a new file that required formatting.
+     * The new hash should be added to the cache.
+     */
+    @Test
+    public void format_new_dirty_java_file() throws Exception {
+        File testFile = dirtyFile();
+
+        mojo.doFormatFile(testFile, rc, cache, basedir, false);
+
+        String cachedHash = (String) cache.get(cacheKey);
+        String expectedHash = mojo.sha512hash(FileUtils.fileRead(testFile));
+        assertEquals(cachedHash, expectedHash);
+    }
+
+    /**
+     * Format a new file that was already formatted.
+     * The content is unchanged, but the file's hash should still be added to the cache.
+     */
+    @Test
+    public void format_new_clean_java_file() throws Exception {
+        File testFile = cleanFile();
+        String filePath = testFile.getCanonicalPath();
+
+        mojo.doFormatFile(testFile, rc, cache, basedir, false);
+
+        String cachedHash = (String) cache.get(cacheKey);
+        String expectedHash = mojo.sha512hash(FileUtils.fileRead(testFile));
+        assertEquals(cachedHash, expectedHash);
+    }
+
+    private File dirtyFile() throws IOException {
+        Files.copy(original, sourceFile);
+        return sourceFile;
+    }
+
+    private File cleanFile() throws IOException, BadLocationException {
+        JavaFormatter formatter = new JavaFormatter();
+        formatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+        File fileToFormat = dirtyFile();
+        String dirtyCode = FileUtils.fileRead(fileToFormat);
+        String formattedCode = formatter.doFormat(dirtyCode, LineEnding.AUTO);
+        FileUtils.fileWrite(fileToFormat, formattedCode);
+        return fileToFormat;
+    }
+
+}

--- a/src/test/java/net/revelc/code/formatter/FormatterMojoTest.java
+++ b/src/test/java/net/revelc/code/formatter/FormatterMojoTest.java
@@ -1,73 +1,92 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package net.revelc.code.formatter;
 
-import com.google.common.io.Files;
-import net.revelc.code.formatter.java.JavaFormatter;
-import org.apache.maven.plugin.MojoExecutionException;
-import org.codehaus.plexus.util.FileUtils;
-import org.eclipse.jface.text.BadLocationException;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import static net.revelc.code.formatter.AbstractFormatterTest.TEST_OUTPUT_DIR;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import static net.revelc.code.formatter.AbstractFormatterTest.TEST_OUTPUT_DIR;
-import static org.junit.jupiter.api.Assertions.*;
+import org.codehaus.plexus.util.FileUtils;
+import org.eclipse.jface.text.BadLocationException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.google.common.io.Files;
+
+import net.revelc.code.formatter.java.JavaFormatter;
 
 class FormatterMojoTest {
 
-    private static final String PREVIOUS_HASH = "_PREVIOUS_HASH_";
+    static final String PREVIOUS_HASH = "_PREVIOUS_HASH_";
+    static final File ORIGINAL = new File("src/test/resources/", "AnyClass.java");
+    static final AtomicInteger FILE_ID = new AtomicInteger(0);
 
     final FormatterMojo mojo = new FormatterMojo();
     final FormatterMojo.ResultCollector rc = new FormatterMojo.ResultCollector();
     final Properties cache = new Properties();
-    final File original = new File("src/test/resources/", "AnyClass.java");
-    final File sourceFile = new File(TEST_OUTPUT_DIR, "AnyClass.java");
+
+    File sourceFile;
     String basedir;
     String cacheKey;
 
     @BeforeEach
     public void setup() throws IOException {
         basedir = TEST_OUTPUT_DIR.getCanonicalPath();
+        sourceFile = new File(TEST_OUTPUT_DIR, "AnyClass" + FILE_ID.incrementAndGet() + ".java");
+        Files.createParentDirs(sourceFile);
+        Files.copy(ORIGINAL, sourceFile);
         cacheKey = sourceFile.getCanonicalPath().substring(basedir.length());
+
         mojo.useEclipseDefaults = true;
         mojo.encoding = "UTF-8";
         mojo.skipJavaFormatting = false;
         mojo.lineEnding = LineEnding.AUTO;
-        mojo.javaFormatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+        mojo.javaFormatter.init(Collections.emptyMap(),
+                new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
     }
 
     /**
-     * Format a known file that changed.
-     * The new hash should be recorded.
+     * Format a known file that changed. The new hash should be recorded.
      */
     @Test
     public void format_known_dirty_java_file() throws Exception {
-        File testFile = dirtyFile();
-        String filePath = testFile.getAbsolutePath();
+        String filePath = sourceFile.getAbsolutePath();
         cache.put(cacheKey, PREVIOUS_HASH);
 
-        mojo.doFormatFile(testFile, rc, cache, basedir, false);
+        mojo.doFormatFile(sourceFile, rc, cache, basedir, false);
 
         String cachedHash = (String) cache.get(cacheKey);
-        String expectedHash = mojo.sha512hash(FileUtils.fileRead(testFile));
+        String expectedHash = mojo.sha512hash(FileUtils.fileRead(sourceFile));
         assertEquals(cachedHash, expectedHash);
     }
 
     /**
-     * Skip a known file that did not change.
-     * The existing hash should remain the same.
+     * Skip a known file that did not change. The existing hash should remain the same.
      */
     @Test
     public void skip_known_unchanged_java_file() throws Exception {
-        File testFile = cleanFile();
-        String filePath = testFile.getAbsolutePath();
+        formatSourceFile();
+        String filePath = sourceFile.getAbsolutePath();
         String unchangedHash = mojo.sha512hash(FileUtils.fileRead(filePath));
         cache.put(cacheKey, unchangedHash);
 
-        mojo.doFormatFile(testFile, rc, cache, basedir, false);
+        mojo.doFormatFile(sourceFile, rc, cache, basedir, false);
 
         String cachedHash = (String) cache.get(cacheKey);
         assertEquals(rc.skippedCount, 1);
@@ -75,49 +94,40 @@ class FormatterMojoTest {
     }
 
     /**
-     * Format a new file that required formatting.
-     * The new hash should be added to the cache.
+     * Format a new file that required formatting. The new hash should be added to the cache.
      */
     @Test
     public void format_new_dirty_java_file() throws Exception {
-        File testFile = dirtyFile();
-
-        mojo.doFormatFile(testFile, rc, cache, basedir, false);
-
+        mojo.doFormatFile(sourceFile, rc, cache, basedir, false);
         String cachedHash = (String) cache.get(cacheKey);
-        String expectedHash = mojo.sha512hash(FileUtils.fileRead(testFile));
+        String expectedHash = mojo.sha512hash(FileUtils.fileRead(sourceFile));
         assertEquals(cachedHash, expectedHash);
     }
 
     /**
-     * Format a new file that was already formatted.
-     * The content is unchanged, but the file's hash should still be added to the cache.
+     * Format a new file that was already formatted. The content is unchanged, but the file's hash should still be added
+     * to the cache. FIXME this test is currently failing, showing how new files are left out of the cache if already
+     * formatted see https://github.com/revelc/formatter-maven-plugin/issues/312
      */
     @Test
     public void format_new_clean_java_file() throws Exception {
-        File testFile = cleanFile();
-        String filePath = testFile.getCanonicalPath();
+        formatSourceFile();
+        String filePath = sourceFile.getCanonicalPath();
 
-        mojo.doFormatFile(testFile, rc, cache, basedir, false);
+        mojo.doFormatFile(sourceFile, rc, cache, basedir, false);
 
         String cachedHash = (String) cache.get(cacheKey);
-        String expectedHash = mojo.sha512hash(FileUtils.fileRead(testFile));
+        String expectedHash = mojo.sha512hash(FileUtils.fileRead(sourceFile));
         assertEquals(cachedHash, expectedHash);
     }
 
-    private File dirtyFile() throws IOException {
-        Files.copy(original, sourceFile);
-        return sourceFile;
-    }
-
-    private File cleanFile() throws IOException, BadLocationException {
+    private void formatSourceFile() throws IOException, BadLocationException {
         JavaFormatter formatter = new JavaFormatter();
         formatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
-        File fileToFormat = dirtyFile();
+        File fileToFormat = sourceFile;
         String dirtyCode = FileUtils.fileRead(fileToFormat);
         String formattedCode = formatter.doFormat(dirtyCode, LineEnding.AUTO);
         FileUtils.fileWrite(fileToFormat, formattedCode);
-        return fileToFormat;
     }
 
 }


### PR DESCRIPTION
Adding four unit tests for the FormatterMojo caching mechanism. One of the tests is **failing**, as a demonstration of #312. If preferred, I could make these new tests part of #313, which fixes the issue.

