### PR TITLE
Add log about fixed line endings

### DIFF
--- a/src/main/java/net/revelc/code/formatter/AbstractCacheableFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/AbstractCacheableFormatter.java
@@ -63,6 +63,8 @@ public abstract class AbstractCacheableFormatter {
                 return Result.SKIPPED;
             }
 
+            this.log.debug("Line endings fixed");
+
             if (!dryRun) {
                 FileUtils.fileWrite(file, this.encoding.name(), formattedCode);
             }


### PR DESCRIPTION
This is done because when looking at logs from
a bunch of files it's hard to determine what actually
happened and make assumptions based on the absence of
log messages.