### PR TITLE
Bring all libraries up to date, moderizer config change, remove deprecated compiler options

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -117,8 +117,6 @@
     <junit.version>5.6.0-M1</junit.version>
 
     <maven.compiler.release>8</maven.compiler.release>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
 
     <!-- skip standard site deployment, because site is deployed using github plugin instead -->
     <maven.site.deploy.skip>true</maven.site.deploy.skip>

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
   </distributionManagement>
 
   <properties>
-    <junit.version>5.6.0-M1</junit.version>
+    <junit.version>5.6.1</junit.version>
 
     <maven.compiler.release>8</maven.compiler.release>
 
@@ -132,92 +132,97 @@
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.commands</artifactId>
-        <version>3.9.600</version>
+        <version>3.9.700</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.contenttype</artifactId>
-        <version>3.7.500</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.expressions</artifactId>
-        <version>3.6.600</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.filesystem</artifactId>
-        <version>1.7.600</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.jobs</artifactId>
-        <version>3.10.600</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.resources</artifactId>
-        <version>3.13.600</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.runtime</artifactId>
-        <version>3.17.0</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.app</artifactId>
-        <version>1.4.300</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.common</artifactId>
-        <version>3.10.600</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.preferences</artifactId>
         <version>3.7.600</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.expressions</artifactId>
+        <version>3.6.700</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.filesystem</artifactId>
+        <version>1.7.700</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.jobs</artifactId>
+        <version>3.10.700</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.resources</artifactId>
+        <version>3.13.700</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.runtime</artifactId>
+        <version>3.17.100</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.app</artifactId>
+        <version>1.4.400</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.common</artifactId>
+        <version>3.11.0</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.preferences</artifactId>
+        <version>3.7.700</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.registry</artifactId>
-        <version>3.8.600</version>
+        <version>3.8.700</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.osgi</artifactId>
-        <version>3.15.100</version>
+        <version>3.15.200</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.text</artifactId>
-        <version>3.10.0</version>
+        <version>3.10.100</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-annotations</artifactId>
+      <version>2.10.3</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
-      <version>2.10.1</version>
+      <version>2.10.3</version>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-      <version>2.10.1</version>
+      <version>2.10.3</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -233,7 +238,7 @@
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>
       <artifactId>jsdt-core</artifactId>
-      <version>2.6.0</version>
+      <version>2.7.0</version>
     </dependency>
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>
@@ -269,12 +274,12 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.20.0</version>
+      <version>3.21.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.12.1</version>
+      <version>1.13.1</version>
     </dependency>
     <dependency>
       <groupId>org.w3c.css</groupId>
@@ -323,7 +328,7 @@
         <plugin>
           <groupId>com.github.ekryd.sortpom</groupId>
           <artifactId>sortpom-maven-plugin</artifactId>
-          <version>2.10.0</version>
+          <version>2.11.0</version>
         </plugin>
         <plugin>
           <groupId>com.github.github</groupId>
@@ -380,7 +385,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.1.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -417,7 +422,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>3.1.1</version>
+          <version>3.2.0</version>
           <configuration>
             <quiet>true</quiet>
             <doclint>all,-missing</doclint>
@@ -453,7 +458,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-site-plugin</artifactId>
-          <version>3.8.2</version>
+          <version>3.9.0</version>
           <dependencies>
             <!-- Fluido is listed here for version update checking only -->
             <dependency>
@@ -494,7 +499,7 @@
         <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
-          <version>2.0.0</version>
+          <version>2.1.0</version>
           <configuration>
             <javaVersion>${maven.compiler.target}</javaVersion>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -279,7 +279,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.13.1</version>
+      <version>1.12.1</version>
     </dependency>
     <dependency>
       <groupId>org.w3c.css</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -626,6 +626,8 @@
                 <ignored>org.junit.jupiter:junit-jupiter-engine</ignored>
                 <!-- ignore transitive dependency overridden to avoid vulnerability -->
                 <ignored>commons-beanutils:commons-beanutils</ignored>
+                <!-- ignore alignment with jackson annotations -->
+                <ignored>com.fasterxml.jackson.core:jackson-annotations</ignored>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -670,6 +670,9 @@
       <plugin>
         <groupId>org.gaul</groupId>
         <artifactId>modernizer-maven-plugin</artifactId>
+        <configuration>
+          <javaVersion>${maven.compiler.release}</javaVersion>
+        </configuration>
         <executions>
           <execution>
             <id>modernizer</id>


### PR DESCRIPTION
- note added jackson annotations directly as they refuse to keep the underlying using that ever aligned release.  This ensures we have same version.  Seems silly on their part since they keep releasing it but they have discussed stopping that release and there was a lot of push back for this very reason.  Not ideal but not entirely bad to keep in sync on our part.

- jsdt-core update to 2.7.1 is not in this yet as I just released it.  I'll follow up with that in next few hours.  With stability of travis questionable when that occurs, want to hold until it's in all release channels.

- modernizer supports up to jdk 15 now.  However, it uses a legacy setup.  Since we require jdk 9 to build, the compiler options that are deprecated are not used so I removed them.  I adjusted this to use the release property.

- All other plugins used at this point that did share the compiler options have since received release that I'm currently aware of.  If you see any concerns there let me know.  I did same on jsdt-core and it had no issues with full release.