### PR TITLE
[config] Sort the xml configuration properties + default to 120 characters

### DIFF
--- a/src/main/resources/formatter-maven-plugin/eclipse/xml.properties
+++ b/src/main/resources/formatter-maven-plugin/eclipse/xml.properties
@@ -15,9 +15,9 @@
 # limitations under the License.
 #
 
-maxLineLength=115
-wrapLongLines=true
+maxLineLength=120
+splitMultiAttrs=false
 tabInsteadOfSpaces=true
 tabWidth=4
-splitMultiAttrs=false
 wellFormedValidation=WARN
+wrapLongLines=true


### PR DESCRIPTION
And change default to 120 characters to match all our other formatting plus terminals are way bigger these days and really probably should be higher.