### PR TITLE
[revert-test] Remove enabled if system property - it already checks t…

### DIFF
--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
 
@@ -29,7 +28,6 @@ import net.revelc.code.formatter.AbstractFormatterTest;
 class HTMLFormatterTest extends AbstractFormatterTest {
 
     @Test
-    @EnabledIfSystemProperty(named = "line.separator", matches = "\\n")
     void testDoFormatFile() throws Exception {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         if (System.lineSeparator().equals("\n")) {

--- a/src/test/java/net/revelc/code/formatter/xml/XMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/xml/XMLFormatterTest.java
@@ -19,7 +19,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
 
@@ -30,7 +29,6 @@ import net.revelc.code.formatter.AbstractFormatterTest;
 class XMLFormatterTest extends AbstractFormatterTest {
 
     @Test
-    @EnabledIfSystemProperty(named = "line.separator", matches = "\\n")
     void testDoFormatFile() throws Exception {
         // Since we set the line endings via options for xml, we cannot rely on CRLF inside doTestFormat.
         // The option will not be available inside xml formatter init so it will use whatever the system


### PR DESCRIPTION
…hat internally

This test is intended to run on all platforms.  Unless there is some oddity on a platform that uses different line endings than *nix / windows (ie is null for some reason), this would work.  This seems like someone was having issues on their machine likely to do some mocking out of system line endings if I had to guess.

Reverts #336 The code was only changed in 2 places and effectively turned off usage on windows.  The very first statement in each tells it to use the system line separator so it can run on windows and linux independently.  I cannot see any way that would be null or not properly set unless someone was testing and mocking things out.  This fixes tests so they are again working in windows in addition to linux.