### PR TITLE
Enhance - do not write the cache file if it did not change

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,17 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 version: 2
 updates:
 - package-ecosystem: maven

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -286,6 +286,8 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
 
     private CssFormatter cssFormatter = new CssFormatter();
 
+    private boolean hashCacheWritten;
+
     /**
      * Execute.
      *
@@ -357,7 +359,11 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
                 }
             }
 
-            storeFileHashCache(hashCache);
+            // Only store the cache if it changed during processing to avoid java properties timestamp writting for
+            // those that want to save the cache
+            if (hashCacheWritten) {
+                storeFileHashCache(hashCache);
+            }
 
             long endClock = System.currentTimeMillis();
 
@@ -597,6 +603,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             formattedHash = sha512hash(Strings.nullToEmpty(formattedCode));
         }
         hashCache.setProperty(path, formattedHash);
+        hashCacheWritten = true;
 
         // If we had determined to skip write, do so now after cache was written
         if (Result.SKIPPED.equals(result)) {


### PR DESCRIPTION
For those that might want to check in the caching files and have automation that might otherwise re-commit since java properties always adds a timestamp entry, this will prevent such a case.  While it doesn't speed things up much, it at least avoid unnecessary write all together.