### PR TITLE
Add a configuration property to allow skipping regions of the source …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,3 +125,7 @@ ver 2.12.0
 ver 2.12.1
 ==========
 - Do not write the cache file if it did not actually write any files for update witin the cache.  This allows users to save the cache to their repository and it will work on both windows/*nix without full rewrites.  The problem with the cache file write when not needed is due to java properties design issue where it logs timestamp upon change.
+
+ver 2.13.0
+==========
+- Add support for excluding certain portions of java code from being reformatted.

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -315,9 +315,6 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * &lt;javaExclusionPattern>\b(from\([^;]*\.end[^;]*?\)\));&lt;/javaExclusionPattern>
      * </code>
      *
-     * Note that this property can also be set using the <code>net.revelc.code.formatter.java.exclusion_pattern</code>
-     * property in the xml configuration file for the java formatter.
-     *
      * @since 2.13
      */
     @Parameter(property = "formatter.java.exclusion_pattern")

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -294,6 +294,35 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
     @Parameter(defaultValue = "false", property = "formatter.useEclipseDefaults")
     private boolean useEclipseDefaults;
 
+    /**
+     * A java regular expression pattern that can be used to exclude some portions of the java code from being
+     * reformatted.
+     *
+     * This can be useful when using DSL that embeds some kind of semantic hierarchy, where users can use various
+     * indentation level to increase the readability of the code. Those semantics are ignored by the formatter, so this
+     * regex pattern can be used to match certain portions of the code so that they will not be reformatted.
+     *
+     * An example is the Apache Camel java DSL which can be used in the following way: <code><pre>
+     * 	from("seda:a").routeId("a")
+     * 			.log("routing at ${routeId}")
+     * 			.multicast()
+     * 				.to("seda:b")
+     * 				.to("seda:c")
+     * 			.end()
+     * 			.log("End of routing");
+     * </pre></code> In the above example, the exercept can be skipped by the formatter by defining the following
+     * property in the formatter xml configuration: <code>
+     * &lt;javaExclusionPattern>\b(from\([^;]*\.end[^;]*?\)\));&lt;/javaExclusionPattern>
+     * </code>
+     *
+     * Note that this property can also be set using the <code>net.revelc.code.formatter.java.exclusion_pattern</code>
+     * property in the xml configuration file for the java formatter.
+     *
+     * @since 2.13
+     */
+    @Parameter(property = "formatter.java.exclusion_pattern")
+    private String javaExclusionPattern;
+
     private JavaFormatter javaFormatter = new JavaFormatter();
 
     private JavascriptFormatter jsFormatter = new JavascriptFormatter();
@@ -713,6 +742,9 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         Map<String, String> javaFormattingOptions = getFormattingOptions(this.configFile);
         if (javaFormattingOptions != null) {
             this.javaFormatter.init(javaFormattingOptions, this);
+        }
+        if (this.javaExclusionPattern != null) {
+            this.javaFormatter.setExclusionPattern(this.javaExclusionPattern);
         }
         // Javascript Setup
         Map<String, String> jsFormattingOptions = getFormattingOptions(this.configJsFile);

--- a/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
@@ -14,13 +14,19 @@
 package net.revelc.code.formatter.java;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.eclipse.jdt.core.ToolFactory;
 import org.eclipse.jdt.core.formatter.CodeFormatter;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.Document;
 import org.eclipse.jface.text.IDocument;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.Region;
 import org.eclipse.text.edits.TextEdit;
 
 import net.revelc.code.formatter.AbstractCacheableFormatter;
@@ -30,21 +36,41 @@ import net.revelc.code.formatter.LineEnding;
 
 public class JavaFormatter extends AbstractCacheableFormatter implements Formatter {
 
+    private static final String EXCLUSION_PATTERN = "net.revelc.code.formatter.java.exclusion_pattern";
+
     private CodeFormatter formatter;
+    private Pattern exclusionPattern;
 
     @Override
     public void init(Map<String, String> options, ConfigurationSource cfg) {
         super.initCfg(cfg);
 
         this.formatter = ToolFactory.createCodeFormatter(options, ToolFactory.M_FORMAT_EXISTING);
+        String ep = options.get(EXCLUSION_PATTERN);
+        if (ep != null) {
+            exclusionPattern = Pattern.compile(ep, Pattern.MULTILINE);
+        }
     }
 
     @Override
     public String doFormat(String code, LineEnding ending) throws IOException, BadLocationException {
         TextEdit te;
         try {
-            te = this.formatter.format(CodeFormatter.K_COMPILATION_UNIT | CodeFormatter.F_INCLUDE_COMMENTS, code, 0,
-                    code.length(), 0, ending.getChars());
+            List<IRegion> regions = new ArrayList<>();
+            int start = 0;
+            if (exclusionPattern != null) {
+                Matcher matcher = exclusionPattern.matcher(code);
+                while (matcher.find()) {
+                    int s = matcher.start();
+                    int e = matcher.end();
+                    regions.add(new Region(start, s - start));
+                    start = e;
+                }
+            }
+            regions.add(new Region(start, code.length() - start));
+
+            te = this.formatter.format(CodeFormatter.K_COMPILATION_UNIT | CodeFormatter.F_INCLUDE_COMMENTS, code,
+                    regions.toArray(new IRegion[0]), 0, ending.getChars());
             if (te == null) {
                 this.log.debug(
                         "Code cannot be formatted. Possible cause is unmatched source/target/compliance version.");

--- a/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
@@ -36,8 +36,6 @@ import net.revelc.code.formatter.LineEnding;
 
 public class JavaFormatter extends AbstractCacheableFormatter implements Formatter {
 
-    private static final String EXCLUSION_PATTERN = "net.revelc.code.formatter.java.exclusion_pattern";
-
     private CodeFormatter formatter;
     private Pattern exclusionPattern;
 
@@ -46,10 +44,6 @@ public class JavaFormatter extends AbstractCacheableFormatter implements Formatt
         super.initCfg(cfg);
 
         this.formatter = ToolFactory.createCodeFormatter(options, ToolFactory.M_FORMAT_EXISTING);
-        String ep = options.get(EXCLUSION_PATTERN);
-        if (ep != null) {
-            setExclusionPattern(ep);
-        }
     }
 
     @Override

--- a/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
@@ -63,4 +63,13 @@ class JavaFormatterTest extends AbstractFormatterTest {
         assertTrue(javaFormatter.isInitialized());
     }
 
+    @Test
+    void testDoFormatFileWithExclusions() throws Exception {
+        JavaFormatter formatter = new JavaFormatter();
+        formatter.setExclusionPattern("\\b(from\\([^;]*\\.end[^;]*?\\));");
+        doTestFormat(Collections.emptyMap(), formatter, "AnyClassExclusion.java",
+                "4044504797bbc1053335564318dfcd22f31a86392a54c032ff97375c5fbbacdd4cf73f352ed17c6e03aa938d707c9253a455065c070a72779e36abf996460790",
+                LineEnding.KEEP);
+    }
+
 }

--- a/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
@@ -67,8 +67,8 @@ class JavaFormatterTest extends AbstractFormatterTest {
     void testDoFormatFileWithExclusions() throws Exception {
         JavaFormatter formatter = new JavaFormatter();
         formatter.setExclusionPattern("\\b(from\\([^;]*\\.end[^;]*?\\));");
-        doTestFormat(Collections.emptyMap(), formatter, "AnyClassExclusion.java",
-                "4044504797bbc1053335564318dfcd22f31a86392a54c032ff97375c5fbbacdd4cf73f352ed17c6e03aa938d707c9253a455065c070a72779e36abf996460790",
+        doTestFormat(Collections.emptyMap(), formatter, "AnyClassExclusionLF.java",
+                "ea4580e667895a179a2baccd4822077e87caa62f2ebb2db0409407de48890b06fa1f7a070db617a4ab156a4e9223d5f2aa99a69209e1f0bdb263a0af7359d43e",
                 LineEnding.KEEP);
     }
 

--- a/src/test/resources/AnyClassExclusion.java
+++ b/src/test/resources/AnyClassExclusion.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.revelc.code.formatter;
+
+import org.apache.camel.builder.RouteBuilder;
+
+public class MulticastRouteTest {
+
+	protected RouteBuilder createRouteBuilder() throws Exception {
+			// bad indentation which should be fixed
+		return new RouteBuilder() {
+			@Override
+			public void configure() throws Exception {
+				from("seda:a").routeId("a")
+						.log("routing at ${routeId}")
+						.multicast()
+							.to("seda:b")
+							.to("seda:c")
+						.end()
+						.log("End of routing");
+			}
+		};
+	}
+}

--- a/src/test/resources/AnyClassExclusionLF.java
+++ b/src/test/resources/AnyClassExclusionLF.java
@@ -15,7 +15,7 @@ package net.revelc.code.formatter;
 
 import org.apache.camel.builder.RouteBuilder;
 
-public class MulticastRouteTest {
+public class AnyClassExclusionLF {
 
 	protected RouteBuilder createRouteBuilder() throws Exception {
 			// bad indentation which should be fixed


### PR DESCRIPTION
…code that match a given regular expression

This is useful when using method chaining in DSL so that we can easily skip the portion of the java code that use the DSL.

This is a first draft, so I'm happy to work on any change you want, but I'd first want to know if you can think about merging it at some point.