### PR TITLE
Change log level for "<type> formatting is skipped" messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -133,3 +133,4 @@ ver 2.12.2
 ver 2.13.0
 ==========
 - Add support for excluding certain portions of java code from being reformatted.
+- Change log level to DEBUG for messages with format "<type> formatting is skipped".

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -575,42 +575,42 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         String formattedCode = null;
         if (file.getName().endsWith(".java") && javaFormatter.isInitialized()) {
             if (skipJavaFormatting) {
-                getLog().info("Java formatting is skipped");
+                getLog().debug("Java formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.javaFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".js") && jsFormatter.isInitialized()) {
             if (skipJsFormatting) {
-                getLog().info("Javascript formatting is skipped");
+                getLog().debug("Javascript formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.jsFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".html") && htmlFormatter.isInitialized()) {
             if (skipHtmlFormatting) {
-                getLog().info("Html formatting is skipped");
+                getLog().debug("Html formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.htmlFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".xml") && xmlFormatter.isInitialized()) {
             if (skipXmlFormatting) {
-                getLog().info("Xml formatting is skipped");
+                getLog().debug("Xml formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.xmlFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".json") && jsonFormatter.isInitialized()) {
             if (skipJsonFormatting) {
-                getLog().info("json formatting is skipped");
+                getLog().debug("json formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.jsonFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".css") && cssFormatter.isInitialized()) {
             if (skipCssFormatting) {
-                getLog().info("css formatting is skipped");
+                getLog().debug("css formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.cssFormatter.formatFile(file, originalCode, this.lineEnding);

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -29,6 +29,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -382,6 +383,8 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             }
         }
 
+        logSkippedTypes();
+
         int numberOfFiles = files.size();
         Log log = getLog();
         log.info("Number of files to be formatted: " + numberOfFiles);
@@ -575,42 +578,42 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         String formattedCode = null;
         if (file.getName().endsWith(".java") && javaFormatter.isInitialized()) {
             if (skipJavaFormatting) {
-                getLog().debug("Java formatting is skipped");
+                log.debug(Type.JAVA + " formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.javaFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".js") && jsFormatter.isInitialized()) {
             if (skipJsFormatting) {
-                getLog().debug("JavaScript formatting is skipped");
+                log.debug(Type.JAVASCRIPT + " formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.jsFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".html") && htmlFormatter.isInitialized()) {
             if (skipHtmlFormatting) {
-                getLog().debug("HTML formatting is skipped");
+                log.debug(Type.HTML + " formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.htmlFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".xml") && xmlFormatter.isInitialized()) {
             if (skipXmlFormatting) {
-                getLog().debug("XML formatting is skipped");
+                log.debug(Type.XML + " formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.xmlFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".json") && jsonFormatter.isInitialized()) {
             if (skipJsonFormatting) {
-                getLog().debug("JSON formatting is skipped");
+                log.debug(Type.JSON + " formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.jsonFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".css") && cssFormatter.isInitialized()) {
             if (skipCssFormatting) {
-                getLog().debug("CSS formatting is skipped");
+                log.debug(Type.CSS + " formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.cssFormatter.formatFile(file, originalCode, this.lineEnding);
@@ -852,6 +855,52 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             map.put(name, properties.getProperty(name));
         }
         return map;
+    }
+
+    /**
+     * Log a message with the list of types that are skipped from formatting. No message is logged if no type is
+     * skipped.
+     */
+    private void logSkippedTypes() {
+        List<Type> skippedTypes = getSkippedTypes();
+
+        if (skippedTypes.isEmpty()) {
+            return;
+        }
+
+        List<String> skippedTypesAsStrings = skippedTypes.stream().map(Type::toString).collect(Collectors.toList());
+
+        getLog().info("Formatting is skipped for types: " + String.join(", ", skippedTypesAsStrings));
+    }
+
+    /**
+     * Get a list of types that are skipped from formatting.
+     *
+     * @return a new list of skipped types; empty list if none are skipped.
+     */
+    private List<Type> getSkippedTypes() {
+        List<Type> skippedTypes = new ArrayList<>();
+
+        if (skipJavaFormatting) {
+            skippedTypes.add(Type.JAVA);
+        }
+        if (skipJsFormatting) {
+            skippedTypes.add(Type.JAVASCRIPT);
+        }
+        if (skipHtmlFormatting) {
+            skippedTypes.add(Type.HTML);
+        }
+        if (skipXmlFormatting) {
+            skippedTypes.add(Type.XML);
+        }
+        if (skipJsonFormatting) {
+            skippedTypes.add(Type.JSON);
+        }
+        if (skipCssFormatting) {
+            skippedTypes.add(Type.CSS);
+        }
+
+        return skippedTypes;
     }
 
     class ResultCollector {

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -866,8 +866,8 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         if (skippedTypes.isEmpty()) {
             return;
         }
-        String skippedTypes = skippedTypes.stream().map(Type::toString).collect(Collectors.joining(", "));
-        getLog().info("Formatting is skipped for types: " + skippedTypes);
+        String skippedTypesStr = skippedTypes.stream().map(Type::toString).collect(Collectors.joining(", "));
+        getLog().info("Formatting is skipped for types: " + skippedTypesStr);
     }
 
     /**

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -863,14 +863,11 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      */
     private void logSkippedTypes() {
         List<Type> skippedTypes = getSkippedTypes();
-
         if (skippedTypes.isEmpty()) {
             return;
         }
-
-        List<String> skippedTypesAsStrings = skippedTypes.stream().map(Type::toString).collect(Collectors.toList());
-
-        getLog().info("Formatting is skipped for types: " + String.join(", ", skippedTypesAsStrings));
+        String skippedTypes = skippedTypes.stream().map(Type::toString).collect(Collectors.joining(", "));
+        getLog().info("Formatting is skipped for types: " + skippedTypes);
     }
 
     /**

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -582,35 +582,35 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             }
         } else if (file.getName().endsWith(".js") && jsFormatter.isInitialized()) {
             if (skipJsFormatting) {
-                getLog().debug("Javascript formatting is skipped");
+                getLog().debug("JavaScript formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.jsFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".html") && htmlFormatter.isInitialized()) {
             if (skipHtmlFormatting) {
-                getLog().debug("Html formatting is skipped");
+                getLog().debug("HTML formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.htmlFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".xml") && xmlFormatter.isInitialized()) {
             if (skipXmlFormatting) {
-                getLog().debug("Xml formatting is skipped");
+                getLog().debug("XML formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.xmlFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".json") && jsonFormatter.isInitialized()) {
             if (skipJsonFormatting) {
-                getLog().debug("json formatting is skipped");
+                getLog().debug("JSON formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.jsonFormatter.formatFile(file, originalCode, this.lineEnding);
             }
         } else if (file.getName().endsWith(".css") && cssFormatter.isInitialized()) {
             if (skipCssFormatting) {
-                getLog().debug("css formatting is skipped");
+                getLog().debug("CSS formatting is skipped");
                 result = Result.SKIPPED;
             } else {
                 formattedCode = this.cssFormatter.formatFile(file, originalCode, this.lineEnding);

--- a/src/main/java/net/revelc/code/formatter/Type.java
+++ b/src/main/java/net/revelc/code/formatter/Type.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.revelc.code.formatter;
+
+/**
+ * Supported types to be formatted
+ */
+public enum Type {
+
+    JAVA("Java"), JAVASCRIPT("JavaScript"), HTML("HTML"), XML("XML"), JSON("JSON"), CSS("CSS");
+
+    private String name;
+
+    Type(String name) {
+        this.name = name;
+    }
+
+    @Override
+    public String toString() {
+        return name;
+    }
+
+}


### PR DESCRIPTION
If you skip certain types of files from formatting and your project have some files of those types then one message per file saying `<type> formatting is skipped` is written on the maven console log providing no value (in part because it does not specify which file was skipped as it is shown on `debug` level).

This change put those logs at the same log level (`debug`) as the one that shows which file is being processed so you have the same information but with the proper context and only when you want to debug some case.
As a replacement for the multiple log messages and to keep providing a way to quickly debug misconfiguration a single log line with all the types skipped from formatting is added as `INFO` level (`Formatting is skipped for types: XML, HTML, ...`)

Also, it corrects the case for types on `<type> formatting is skipped` messages.
The case of the types on the mentioned messages were in "Sentence case" but they are acronyms and the common/general way to put them is with uppercase. Another case is `Javascript` which the proper name is `JavaScript` (with capital S).

## Before

![maven console normal - before](https://user-images.githubusercontent.com/1738654/94502998-cd5fb800-01db-11eb-80df-e008c6f7c4a4.png)
![maven console debug - before](https://user-images.githubusercontent.com/1738654/94503001-d0f33f00-01db-11eb-8299-7d32cc83d5b5.png)

## After
![maven console normal - after](https://user-images.githubusercontent.com/1738654/94757801-b5ba3800-0371-11eb-9692-327eae4f61ab.png)
![maven console debug - after](https://user-images.githubusercontent.com/1738654/94503013-d81a4d00-01db-11eb-9833-0b6cc6f01fc7.png)
