### PR TITLE
Use nanos for correct duration calculations

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -13,6 +13,8 @@
  */
 package net.revelc.code.formatter;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
@@ -352,7 +354,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             return;
         }
 
-        long startClock = System.currentTimeMillis();
+        long startClock = System.nanoTime();
 
         if (StringUtils.isEmpty(this.encoding)) {
             this.encoding = ReaderFactory.FILE_ENCODING;
@@ -395,8 +397,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             Properties hashCache = readFileHashCacheFile();
 
             String basedirPath = getBasedirPath();
-            for (int i = 0, n = files.size(); i < n; i++) {
-                File file = files.get(i);
+            for (File file : files) {
                 if (file.exists()) {
                     if (file.canWrite()) {
                         formatFile(file, rc, hashCache, basedirPath);
@@ -414,13 +415,13 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
                 storeFileHashCache(hashCache);
             }
 
-            long endClock = System.currentTimeMillis();
+            long duration = NANOSECONDS.toSeconds(System.nanoTime() - startClock);
 
             log.info("Successfully formatted:          " + rc.successCount + FILE_S);
             log.info("Fail to format:                  " + rc.failCount + FILE_S);
             log.info("Skipped:                         " + rc.skippedCount + FILE_S);
             log.info("Read only skipped:               " + rc.readOnlyCount + FILE_S);
-            log.info("Approximate time taken:          " + ((endClock - startClock) / 1000) + "s");
+            log.info("Approximate time taken:          " + duration + "s");
         }
     }
 


### PR DESCRIPTION
Use `System.nanoTime()` instead of `System.currentTimeMillis()` for
computing relative time intervals correctly. Nano-time is not useful for
absolute time, but it is better for relative time/durations, because the
difference between one time and a subsequent time is always positive and
not affected by system clock changes.