### PR TITLE
Bump plugin and update cache javadoc

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,7 +366,7 @@
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.13.0</version>
+          <version>2.14.0</version>
           <configuration>
             <configFile>${project.basedir}/src/main/resources/formatter-maven-plugin/eclipse/java.xml</configFile>
             <configJsFile>${project.basedir}/src/main/resources/formatter-maven-plugin/eclipse/javascript.xml</configJsFile>

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -136,6 +136,11 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      * survive clean phase when it should. This is not intended to be clean in that way as one would want as close to a
      * no-op as possible when files are already all formatted and/or have not been otherwise touched. This is used based
      * off the files in the project so it is as much part of the source as any other file is.
+     *
+     * <p>
+     * The cache can become invalid for any number of reasons that this plugin can't reasonably detect automatically. If
+     * you rely on the cache and make any changes to the project that could conceivably make the cache invalid, or if
+     * you notice that files aren't being reformatted when they should, just delete the cache and it will be rebuilt.
      * 
      * @since 2.12.1
      */


### PR DESCRIPTION
* Bump formatter to latest release for current build
* Update the javadoc for the cache to warn about changes a user might
  make that would invalidate any cache (re #453)