### PR TITLE
Add capacity to use a custom base diretory

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -114,9 +114,9 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
     private File targetDirectory;
 
     /**
-     * Project's base directory.
+     * Project's base directory as specified in the POM.
      */
-    @Parameter(defaultValue = ".", property = "project.basedir", readonly = true, required = true)
+    @Parameter(defaultValue = "${project.basedir}", property = "baseDirectory", readonly = true, required = true)
     private File basedir;
 
     /**


### PR DESCRIPTION
In some rare use case it could be good to use the plugin outside the project to format. For example when all the project don't share the same parent pom we could use a generic pom to automatically format code at pre commit like [this](https://github.com/brun-nico/formatter-maven-plugin).

To do that it's necessary to specify the base directory because in this case the base directory isn't equal to project.basedir.