### PR TITLE
Bump dependencies for Eclipse 2021-06

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,3 +146,9 @@ ver 2.15.0
 ==========
 - Support Eclipse 2021-03 (4.19, JDT 3.25)
 
+ver 2.16.0
+==========
+- Support Eclipse 2021-06 (4.20, JDT 3.26)
+- Support overriding base directory
+- Move docs about version compatibility to src/site/
+

--- a/pom.xml
+++ b/pom.xml
@@ -145,13 +145,13 @@
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.commands</artifactId>
-        <version>3.9.800</version>
+        <version>3.10.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.contenttype</artifactId>
-        <version>3.7.900</version>
+        <version>3.7.1000</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
@@ -163,25 +163,25 @@
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.filesystem</artifactId>
-        <version>1.7.700</version>
+        <version>1.9.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.jobs</artifactId>
-        <version>3.10.1100</version>
+        <version>3.11.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.resources</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.runtime</artifactId>
-        <version>3.20.100</version>
+        <version>3.22.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
@@ -193,7 +193,7 @@
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.common</artifactId>
-        <version>3.14.100</version>
+        <version>3.15.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
@@ -205,25 +205,25 @@
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.registry</artifactId>
-        <version>3.10.100</version>
+        <version>3.10.200</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.osgi</artifactId>
-        <version>3.16.200</version>
+        <version>3.16.300</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.team.core</artifactId>
-        <version>3.8.1100</version>
+        <version>3.9.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.text</artifactId>
-        <version>3.11.0</version>
+        <version>3.12.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -290,7 +290,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.25.0</version>
+      <version>3.26.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>
@@ -401,6 +401,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
+          <!-- skip over 3.2.0 due to https://issues.apache.org/jira/browse/MDEP-753 -->
           <version>3.1.2</version>
         </plugin>
         <plugin>
@@ -801,7 +802,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -814,7 +815,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -828,7 +829,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                     <pluginExecution>
@@ -841,7 +842,7 @@
                         </goals>
                       </pluginExecutionFilter>
                       <action>
-                        <ignore/>
+                        <ignore />
                       </action>
                     </pluginExecution>
                   </pluginExecutions>

--- a/src/site/markdown/eclipse-versions.md.vm
+++ b/src/site/markdown/eclipse-versions.md.vm
@@ -26,6 +26,7 @@ their compatibility with major Eclipse releases.
 
 formatter-maven-plugin | Eclipse<br/>Name | Eclipse<br/>Version | JDT Core
 -----------------------|------------------|---------------------|---------
+2.16                   | 2021-06          | 4.20                | 3.26
 2.15                   | 2021-03          | 4.19                | 3.25
 2.14                   | 2020-12          | 4.18                | 3.24
 2.13                   | 2020-09          | 4.17                | 3.23


### PR DESCRIPTION
* Bump JDT Core to 3.26
* Bump JDT Core's transitive dependencies
* Update compatibility doc and CHANGELOG
* Also bump maven-dependency-plugin