### PR TITLE
[pom] Bump jsdt-core to 2.8.1 (this is eclipse javascript for 2020-09) - see notes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -254,7 +254,7 @@
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>
       <artifactId>jsdt-core</artifactId>
-      <version>2.8.0</version>
+      <version>2.8.1</version>
     </dependency>
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
Because we pull this from P2, all versions post this release require java 11.  While that doesn't mean they are all really java 11, it does mean it is rather impossible for us to check as we just rebundle not compile.  So bumping here until we can figure out if we need to move to jdk 11.