### PR TITLE
[css] Add patch to retain \9 during css formatting as cssparser conversions fixes #522

### DIFF
--- a/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
@@ -57,6 +57,9 @@ public class CssFormatter extends AbstractCacheableFormatter implements Formatte
         CSSStyleSheetImpl sheet = (CSSStyleSheetImpl) parser.parseStyleSheet(source, null, null);
         String formattedCode = sheet.getCssText(formatter);
 
+        // Patch converted 'tab' back to '\9' for IE 7,8, and 9 hack. Cssparser switches it to 'tab'.
+        formattedCode = formattedCode.replace("\t;", "\\9;");
+
         if (code.equals(formattedCode)) {
             return null;
         }

--- a/src/test/java/net/revelc/code/formatter/css/CssFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/css/CssFormatterTest.java
@@ -32,10 +32,10 @@ class CssFormatterTest extends AbstractFormatterTest {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(new CssFormatter(), "someFile.css",
-                    "80042a8a00870195a43c6a80e8e0b2d13e3ac8fd3f52e10277f05a637af6bb5bdddcf5b939677be0b48b907a74861f3f3cd71be38edf4f740c7e9f31d79b1ee1");
+                    "72b2c33020774b407c2e49a849e47990941d3c80d982b1a4ef2e0ffed605b85e2680fca57cfdbc9d6cd2fc6fc0236dbeb915fd75f530689c7e90a3745316b6a3");
         } else {
             doTestFormat(new CssFormatter(), "someFile.css",
-                    "332e3475ccfcb029ba8db3fd1d9ebd7e44dad60d96866de50e0434c0075a41e138c3fc919410780e985c69e6975d86cf18c2048ab1311cb382218db82dfaa79e");
+                    "684255d79eb28c6f4cfa340b6930fe1cfd9de16a1c6abf5f54e8f6837694b599101ef247ed00b8aea5460aa64cda60b418cebefd8ea28d5e747ed9cf4c3a9274");
         }
     }
 


### PR DESCRIPTION
fixes #522 

An old IE css hack that uses \9; is failing with the formatter as it is first translated to a tab then subsequent passes delete it entirelly.  Because our own test file had this specific hack logic, we should fix as we are formatting logic not trying to rewrite logic incorrectly.  There is a given that ie 7,8,9 is likely not used but also these usually come in pairs and file maintainer should remove any ie hacks on their own.  The changes implied by auto doing that could cause differences in css usage across all browsers as it would duplicate entries.