### PR TITLE
[tests] Rewrite all tests to do two passes and always write file results to disk before assertion checks - fixes #523

### DIFF
--- a/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
@@ -91,7 +91,8 @@ public abstract class AbstractFormatterTest {
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(Collections.emptyMap(), formatter, fileUnderTest, expectedSha512, LineEnding.LF, formatCycle);
         } else {
-            doTestFormat(Collections.emptyMap(), formatter, fileUnderTest, expectedSha512, LineEnding.CRLF, formatCycle);
+            doTestFormat(Collections.emptyMap(), formatter, fileUnderTest, expectedSha512, LineEnding.CRLF,
+                    formatCycle);
         }
     }
 

--- a/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/AbstractFormatterTest.java
@@ -88,7 +88,11 @@ public abstract class AbstractFormatterTest {
 
     protected void doTestFormat(Formatter formatter, String fileUnderTest, String expectedSha512,
             FormatCycle formatCycle) throws IOException {
-        doTestFormat(Collections.emptyMap(), formatter, fileUnderTest, expectedSha512, LineEnding.CRLF, formatCycle);
+        if (System.lineSeparator().equals("\n")) {
+            doTestFormat(Collections.emptyMap(), formatter, fileUnderTest, expectedSha512, LineEnding.LF, formatCycle);
+        } else {
+            doTestFormat(Collections.emptyMap(), formatter, fileUnderTest, expectedSha512, LineEnding.CRLF, formatCycle);
+        }
     }
 
     protected void doTestFormat(Map<String, String> options, Formatter formatter, String fileUnderTest,

--- a/src/test/java/net/revelc/code/formatter/FormatCycle.java
+++ b/src/test/java/net/revelc/code/formatter/FormatCycle.java
@@ -1,0 +1,18 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.revelc.code.formatter;
+
+public enum FormatCycle {
+    FIRST, SECOND
+}

--- a/src/test/java/net/revelc/code/formatter/css/CssFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/css/CssFormatterTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
+import net.revelc.code.formatter.FormatCycle;
 
 /**
  * @author yoshiman
@@ -32,10 +33,18 @@ class CssFormatterTest extends AbstractFormatterTest {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(new CssFormatter(), "someFile.css",
-                    "72b2c33020774b407c2e49a849e47990941d3c80d982b1a4ef2e0ffed605b85e2680fca57cfdbc9d6cd2fc6fc0236dbeb915fd75f530689c7e90a3745316b6a3");
+                    "72b2c33020774b407c2e49a849e47990941d3c80d982b1a4ef2e0ffed605b85e2680fca57cfdbc9d6cd2fc6fc0236dbeb915fd75f530689c7e90a3745316b6a3",
+                    FormatCycle.FIRST);
+            doTestFormat(new CssFormatter(), "someFile.css",
+                    "72b2c33020774b407c2e49a849e47990941d3c80d982b1a4ef2e0ffed605b85e2680fca57cfdbc9d6cd2fc6fc0236dbeb915fd75f530689c7e90a3745316b6a3",
+                    FormatCycle.SECOND);
         } else {
             doTestFormat(new CssFormatter(), "someFile.css",
-                    "684255d79eb28c6f4cfa340b6930fe1cfd9de16a1c6abf5f54e8f6837694b599101ef247ed00b8aea5460aa64cda60b418cebefd8ea28d5e747ed9cf4c3a9274");
+                    "684255d79eb28c6f4cfa340b6930fe1cfd9de16a1c6abf5f54e8f6837694b599101ef247ed00b8aea5460aa64cda60b418cebefd8ea28d5e747ed9cf4c3a9274",
+                    FormatCycle.FIRST);
+            doTestFormat(new CssFormatter(), "someFile.css",
+                    "684255d79eb28c6f4cfa340b6930fe1cfd9de16a1c6abf5f54e8f6837694b599101ef247ed00b8aea5460aa64cda60b418cebefd8ea28d5e747ed9cf4c3a9274",
+                    FormatCycle.SECOND);
         }
     }
 
@@ -43,7 +52,8 @@ class CssFormatterTest extends AbstractFormatterTest {
     void testIsIntialized() throws Exception {
         CssFormatter cssFormatter = new CssFormatter();
         assertFalse(cssFormatter.isInitialized());
-        cssFormatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+        cssFormatter.init(Collections.emptyMap(),
+                new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_PRIMARY_DIR));
 
         assertTrue(cssFormatter.isInitialized());
     }

--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
+import net.revelc.code.formatter.FormatCycle;
 
 /**
  * @author yoshiman
@@ -32,10 +33,18 @@ class HTMLFormatterTest extends AbstractFormatterTest {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(new HTMLFormatter(), "someFile.html",
-                    "1cfe5e48635d8618be4d490a5e7f690ef8e1dfc7e24303457030e281068bbebac44b552ae52ac88f03bf10e72ed0582904d665afc54bade395fd3d183abe0cba");
+                    "1cfe5e48635d8618be4d490a5e7f690ef8e1dfc7e24303457030e281068bbebac44b552ae52ac88f03bf10e72ed0582904d665afc54bade395fd3d183abe0cba",
+                    FormatCycle.FIRST);
+            doTestFormat(new HTMLFormatter(), "someFile.html",
+                    "1cfe5e48635d8618be4d490a5e7f690ef8e1dfc7e24303457030e281068bbebac44b552ae52ac88f03bf10e72ed0582904d665afc54bade395fd3d183abe0cba",
+                    FormatCycle.SECOND);
         } else {
             doTestFormat(new HTMLFormatter(), "someFile.html",
-                    "57b5eae0562d6abc4d4e874b675c8351282b0c4797a19891c82bb5e1c50c5ede9bda6d1d9490a775e0d5f56f0521854d321de78782760d5fb8567680a25c307c");
+                    "57b5eae0562d6abc4d4e874b675c8351282b0c4797a19891c82bb5e1c50c5ede9bda6d1d9490a775e0d5f56f0521854d321de78782760d5fb8567680a25c307c",
+                    FormatCycle.FIRST);
+            doTestFormat(new HTMLFormatter(), "someFile.html",
+                    "57b5eae0562d6abc4d4e874b675c8351282b0c4797a19891c82bb5e1c50c5ede9bda6d1d9490a775e0d5f56f0521854d321de78782760d5fb8567680a25c307c",
+                    FormatCycle.SECOND);
         }
     }
 
@@ -43,7 +52,8 @@ class HTMLFormatterTest extends AbstractFormatterTest {
     void testIsIntialized() throws Exception {
         HTMLFormatter htmlFormatter = new HTMLFormatter();
         assertFalse(htmlFormatter.isInitialized());
-        htmlFormatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+        htmlFormatter.init(Collections.emptyMap(),
+                new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_PRIMARY_DIR));
         assertTrue(htmlFormatter.isInitialized());
     }
 

--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -35,16 +35,18 @@ class HTMLFormatterTest extends AbstractFormatterTest {
             doTestFormat(new HTMLFormatter(), "someFile.html",
                     "1cfe5e48635d8618be4d490a5e7f690ef8e1dfc7e24303457030e281068bbebac44b552ae52ac88f03bf10e72ed0582904d665afc54bade395fd3d183abe0cba",
                     FormatCycle.FIRST);
-            doTestFormat(new HTMLFormatter(), "someFile.html",
-                    "1cfe5e48635d8618be4d490a5e7f690ef8e1dfc7e24303457030e281068bbebac44b552ae52ac88f03bf10e72ed0582904d665afc54bade395fd3d183abe0cba",
-                    FormatCycle.SECOND);
+            // TODO: jsoup has further bugs to fix so this always fails currently
+            // doTestFormat(new HTMLFormatter(), "someFile.html",
+            // "1cfe5e48635d8618be4d490a5e7f690ef8e1dfc7e24303457030e281068bbebac44b552ae52ac88f03bf10e72ed0582904d665afc54bade395fd3d183abe0cba",
+            // FormatCycle.SECOND);
         } else {
             doTestFormat(new HTMLFormatter(), "someFile.html",
                     "57b5eae0562d6abc4d4e874b675c8351282b0c4797a19891c82bb5e1c50c5ede9bda6d1d9490a775e0d5f56f0521854d321de78782760d5fb8567680a25c307c",
                     FormatCycle.FIRST);
-            doTestFormat(new HTMLFormatter(), "someFile.html",
-                    "57b5eae0562d6abc4d4e874b675c8351282b0c4797a19891c82bb5e1c50c5ede9bda6d1d9490a775e0d5f56f0521854d321de78782760d5fb8567680a25c307c",
-                    FormatCycle.SECOND);
+            // TODO: jsoup has further bugs to fix so this always fails currently
+            // doTestFormat(new HTMLFormatter(), "someFile.html",
+            // "57b5eae0562d6abc4d4e874b675c8351282b0c4797a19891c82bb5e1c50c5ede9bda6d1d9490a775e0d5f56f0521854d321de78782760d5fb8567680a25c307c",
+            // FormatCycle.SECOND);
         }
     }
 

--- a/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
+import net.revelc.code.formatter.FormatCycle;
 import net.revelc.code.formatter.LineEnding;
 
 /**
@@ -31,35 +32,49 @@ class JavaFormatterTest extends AbstractFormatterTest {
     @Test
     void testDoFormatFile() throws Exception {
         doTestFormat(new JavaFormatter(), "AnyClass.java",
-                "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca");
+                "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca",
+                FormatCycle.FIRST);
+        doTestFormat(new JavaFormatter(), "AnyClass.java",
+                "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca",
+                FormatCycle.SECOND);
     }
 
     @Test
     void testDoFormatFileKeepLineFeedLF() throws Exception {
         doTestFormat(Collections.emptyMap(), new JavaFormatter(), "AnyClassLF.java",
                 "5d41510e74b87c6b38c8e4692d53aa9de3d7a85d08c72697b77c48541534147a028e799289d49c05cc9a3cc601e64c86bb954bb62b03b7277616b71ecc5bd716",
-                LineEnding.KEEP);
+                LineEnding.KEEP, FormatCycle.FIRST);
+        doTestFormat(Collections.emptyMap(), new JavaFormatter(), "AnyClassLF.java",
+                "5d41510e74b87c6b38c8e4692d53aa9de3d7a85d08c72697b77c48541534147a028e799289d49c05cc9a3cc601e64c86bb954bb62b03b7277616b71ecc5bd716",
+                LineEnding.KEEP, FormatCycle.SECOND);
     }
 
     @Test
     void testDoFormatFileKeepLineFeedCR() throws Exception {
         doTestFormat(Collections.emptyMap(), new JavaFormatter(), "AnyClassCR.java",
                 "cf44c525667d8c49c80d390215e4d1995c10e8966583da0920e3917837188e5b95159f9dc7b4ae2559fbfa4550cbbaca166edc8991907d5fd4bbc74a1402e97e",
-                LineEnding.KEEP);
+                LineEnding.KEEP, FormatCycle.FIRST);
+        doTestFormat(Collections.emptyMap(), new JavaFormatter(), "AnyClassCR.java",
+                "cf44c525667d8c49c80d390215e4d1995c10e8966583da0920e3917837188e5b95159f9dc7b4ae2559fbfa4550cbbaca166edc8991907d5fd4bbc74a1402e97e",
+                LineEnding.KEEP, FormatCycle.SECOND);
     }
 
     @Test
     void testDoFormatFileKeepLineFeedCRLF() throws Exception {
         doTestFormat(Collections.emptyMap(), new JavaFormatter(), "AnyClassCRLF.java",
                 "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca",
-                LineEnding.KEEP);
+                LineEnding.KEEP, FormatCycle.FIRST);
+        doTestFormat(Collections.emptyMap(), new JavaFormatter(), "AnyClassCRLF.java",
+                "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca",
+                LineEnding.KEEP, FormatCycle.SECOND);
     }
 
     @Test
     void testIsIntialized() throws Exception {
         JavaFormatter javaFormatter = new JavaFormatter();
         assertFalse(javaFormatter.isInitialized());
-        javaFormatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+        javaFormatter.init(Collections.emptyMap(),
+                new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_PRIMARY_DIR));
         assertTrue(javaFormatter.isInitialized());
     }
 
@@ -69,7 +84,10 @@ class JavaFormatterTest extends AbstractFormatterTest {
         formatter.setExclusionPattern("\\b(from\\([^;]*\\.end[^;]*?\\));");
         doTestFormat(Collections.emptyMap(), formatter, "AnyClassExclusionLF.java",
                 "ea4580e667895a179a2baccd4822077e87caa62f2ebb2db0409407de48890b06fa1f7a070db617a4ab156a4e9223d5f2aa99a69209e1f0bdb263a0af7359d43e",
-                LineEnding.KEEP);
+                LineEnding.KEEP, FormatCycle.FIRST);
+        doTestFormat(Collections.emptyMap(), formatter, "AnyClassExclusionLF.java",
+                "ea4580e667895a179a2baccd4822077e87caa62f2ebb2db0409407de48890b06fa1f7a070db617a4ab156a4e9223d5f2aa99a69209e1f0bdb263a0af7359d43e",
+                LineEnding.KEEP, FormatCycle.SECOND);
     }
 
 }

--- a/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
@@ -31,12 +31,21 @@ class JavaFormatterTest extends AbstractFormatterTest {
 
     @Test
     void testDoFormatFile() throws Exception {
-        doTestFormat(new JavaFormatter(), "AnyClass.java",
-                "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca",
-                FormatCycle.FIRST);
-        doTestFormat(new JavaFormatter(), "AnyClass.java",
-                "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca",
-                FormatCycle.SECOND);
+        if (System.lineSeparator().equals("\n")) {
+            doTestFormat(new JavaFormatter(), "AnyClass.java",
+                    "5d41510e74b87c6b38c8e4692d53aa9de3d7a85d08c72697b77c48541534147a028e799289d49c05cc9a3cc601e64c86bb954bb62b03b7277616b71ecc5bd716",
+                    FormatCycle.FIRST);
+            doTestFormat(new JavaFormatter(), "AnyClass.java",
+                    "5d41510e74b87c6b38c8e4692d53aa9de3d7a85d08c72697b77c48541534147a028e799289d49c05cc9a3cc601e64c86bb954bb62b03b7277616b71ecc5bd716",
+                    FormatCycle.SECOND);
+        } else {
+            doTestFormat(new JavaFormatter(), "AnyClass.java",
+                    "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca",
+                    FormatCycle.FIRST);
+            doTestFormat(new JavaFormatter(), "AnyClass.java",
+                    "fe7bdeec160a33a744209602d1ae99f94bd8ff433dd3ab856bcf6857588170d5c69b027f15c72bd7a6c0ae6e3659a9ab62196fa198366ec0c0722286257cbdca",
+                    FormatCycle.SECOND);
+        }
     }
 
     @Test

--- a/src/test/java/net/revelc/code/formatter/javascript/JavascriptFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/javascript/JavascriptFormatterTest.java
@@ -27,12 +27,21 @@ class JavascriptFormatterTest extends AbstractFormatterTest {
 
     @Test
     void testDoFormatFile() throws Exception {
-        doTestFormat(new JavascriptFormatter(), "AnyJS.js",
-                "33020bfa1ecebd935b6d6ba8e482bc14433ad52899ca63bd892fbb85d20e835ad183dba1e0a6203a72fbbb3d859b6f6872e320a8ea2fa93c9b2ca301ae7c6ec8",
-                FormatCycle.FIRST);
-        doTestFormat(new JavascriptFormatter(), "AnyJS.js",
-                "33020bfa1ecebd935b6d6ba8e482bc14433ad52899ca63bd892fbb85d20e835ad183dba1e0a6203a72fbbb3d859b6f6872e320a8ea2fa93c9b2ca301ae7c6ec8",
-                FormatCycle.SECOND);
+        if (System.lineSeparator().equals("\n")) {
+            doTestFormat(new JavascriptFormatter(), "AnyJS.js",
+                    "d2a196d7aaddc3285b783d929965c884d1c1cacf15e777f0a7a7315355822b51f903fdb5b47f7f6c79ffc35e2f2dee58b605578a8b18afb91cdfed4624f03d7d",
+                    FormatCycle.FIRST);
+            doTestFormat(new JavascriptFormatter(), "AnyJS.js",
+                    "d2a196d7aaddc3285b783d929965c884d1c1cacf15e777f0a7a7315355822b51f903fdb5b47f7f6c79ffc35e2f2dee58b605578a8b18afb91cdfed4624f03d7d",
+                    FormatCycle.SECOND);
+        } else {
+            doTestFormat(new JavascriptFormatter(), "AnyJS.js",
+                    "33020bfa1ecebd935b6d6ba8e482bc14433ad52899ca63bd892fbb85d20e835ad183dba1e0a6203a72fbbb3d859b6f6872e320a8ea2fa93c9b2ca301ae7c6ec8",
+                    FormatCycle.FIRST);
+            doTestFormat(new JavascriptFormatter(), "AnyJS.js",
+                    "33020bfa1ecebd935b6d6ba8e482bc14433ad52899ca63bd892fbb85d20e835ad183dba1e0a6203a72fbbb3d859b6f6872e320a8ea2fa93c9b2ca301ae7c6ec8",
+                    FormatCycle.SECOND);
+        }
     }
 
     @Test

--- a/src/test/java/net/revelc/code/formatter/javascript/JavascriptFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/javascript/JavascriptFormatterTest.java
@@ -21,20 +21,26 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
+import net.revelc.code.formatter.FormatCycle;
 
 class JavascriptFormatterTest extends AbstractFormatterTest {
 
     @Test
     void testDoFormatFile() throws Exception {
         doTestFormat(new JavascriptFormatter(), "AnyJS.js",
-                "33020bfa1ecebd935b6d6ba8e482bc14433ad52899ca63bd892fbb85d20e835ad183dba1e0a6203a72fbbb3d859b6f6872e320a8ea2fa93c9b2ca301ae7c6ec8");
+                "33020bfa1ecebd935b6d6ba8e482bc14433ad52899ca63bd892fbb85d20e835ad183dba1e0a6203a72fbbb3d859b6f6872e320a8ea2fa93c9b2ca301ae7c6ec8",
+                FormatCycle.FIRST);
+        doTestFormat(new JavascriptFormatter(), "AnyJS.js",
+                "33020bfa1ecebd935b6d6ba8e482bc14433ad52899ca63bd892fbb85d20e835ad183dba1e0a6203a72fbbb3d859b6f6872e320a8ea2fa93c9b2ca301ae7c6ec8",
+                FormatCycle.SECOND);
     }
 
     @Test
     void testIsIntialized() throws Exception {
         JavascriptFormatter jsFormatter = new JavascriptFormatter();
         assertFalse(jsFormatter.isInitialized());
-        jsFormatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+        jsFormatter.init(Collections.emptyMap(),
+                new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_PRIMARY_DIR));
         assertTrue(jsFormatter.isInitialized());
     }
 

--- a/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
@@ -73,10 +73,10 @@ class JsonFormatterTest extends AbstractFormatterTest {
         // default is regardless of requesting it to be CRLF later which is ignored.
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
-                    "2122f00ff5a3b4d3012d568b907deaecee248b5b1f8e3ebe213f6b7b3a628ad0c14d236e79789763d940f346c689694ac9854fe8fe7d935a50286e65c036a36d",
+                    "0ca303fef968b92f3f798ff1615cd6c501ea3b754fd18f54932fd07c1dce86d2df9845817b8f521a2254c98c6e0d35b0bced3ea12113e961d3789111868897d7",
                     LineEnding.LF, FormatCycle.FIRST);
             doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
-                    "2122f00ff5a3b4d3012d568b907deaecee248b5b1f8e3ebe213f6b7b3a628ad0c14d236e79789763d940f346c689694ac9854fe8fe7d935a50286e65c036a36d",
+                    "0ca303fef968b92f3f798ff1615cd6c501ea3b754fd18f54932fd07c1dce86d2df9845817b8f521a2254c98c6e0d35b0bced3ea12113e961d3789111868897d7",
                     LineEnding.LF, FormatCycle.SECOND);
         } else {
             doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",

--- a/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
@@ -74,10 +74,10 @@ class JsonFormatterTest extends AbstractFormatterTest {
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
                     "2122f00ff5a3b4d3012d568b907deaecee248b5b1f8e3ebe213f6b7b3a628ad0c14d236e79789763d940f346c689694ac9854fe8fe7d935a50286e65c036a36d",
-                    LineEnding.CRLF, FormatCycle.FIRST);
+                    LineEnding.LF, FormatCycle.FIRST);
             doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
                     "2122f00ff5a3b4d3012d568b907deaecee248b5b1f8e3ebe213f6b7b3a628ad0c14d236e79789763d940f346c689694ac9854fe8fe7d935a50286e65c036a36d",
-                    LineEnding.CRLF, FormatCycle.SECOND);
+                    LineEnding.LF, FormatCycle.SECOND);
         } else {
             doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
                     "5d433f2700a2fdabfabdb309d5f807df91ad86f7a94658d4a3f2f3699ae78b2efb1de451c141f61905f1c814cd647f312ae9651454e65d124510be0573082e86",

--- a/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
@@ -37,10 +37,10 @@ class JsonFormatterTest extends AbstractFormatterTest {
         // default is regardless of requesting it to be CRLF later which is ignored.
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(new JsonFormatter(), "someFile.json",
-                    "4f74200377cfd8a1ee31622ef212268ceb6db177c2bc39481828aba1581869f593ec059c987d18d02f77a134084e8ccf2d016fe28ecc2209d81ffabfc885fae3",
+                    "1c8b8931b79a7dfaa4d2ab1986ebfe5967716b63877aa0311091214bf870f5480469a80e920fc825a98ad265f252e94e1ca4b94a55a279d0d2d302a20dcb4fa3",
                     FormatCycle.FIRST);
             doTestFormat(new JsonFormatter(), "someFile.json",
-                    "4f74200377cfd8a1ee31622ef212268ceb6db177c2bc39481828aba1581869f593ec059c987d18d02f77a134084e8ccf2d016fe28ecc2209d81ffabfc885fae3",
+                    "1c8b8931b79a7dfaa4d2ab1986ebfe5967716b63877aa0311091214bf870f5480469a80e920fc825a98ad265f252e94e1ca4b94a55a279d0d2d302a20dcb4fa3",
                     FormatCycle.SECOND);
         } else {
             doTestFormat(new JsonFormatter(), "someFile.json",

--- a/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
+import net.revelc.code.formatter.FormatCycle;
 import net.revelc.code.formatter.LineEnding;
 
 /**
@@ -36,10 +37,18 @@ class JsonFormatterTest extends AbstractFormatterTest {
         // default is regardless of requesting it to be CRLF later which is ignored.
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(new JsonFormatter(), "someFile.json",
-                    "4f74200377cfd8a1ee31622ef212268ceb6db177c2bc39481828aba1581869f593ec059c987d18d02f77a134084e8ccf2d016fe28ecc2209d81ffabfc885fae3");
+                    "4f74200377cfd8a1ee31622ef212268ceb6db177c2bc39481828aba1581869f593ec059c987d18d02f77a134084e8ccf2d016fe28ecc2209d81ffabfc885fae3",
+                    FormatCycle.FIRST);
+            doTestFormat(new JsonFormatter(), "someFile.json",
+                    "4f74200377cfd8a1ee31622ef212268ceb6db177c2bc39481828aba1581869f593ec059c987d18d02f77a134084e8ccf2d016fe28ecc2209d81ffabfc885fae3",
+                    FormatCycle.SECOND);
         } else {
             doTestFormat(new JsonFormatter(), "someFile.json",
-                    "c6e19e9d042d8d2045eb17d2966f105e6c538d5c05c614c556eb88dfb020645cb2d410cf059643a14ca193487b888e24194499ee8be2c337afdc89067a23e4cd");
+                    "c6e19e9d042d8d2045eb17d2966f105e6c538d5c05c614c556eb88dfb020645cb2d410cf059643a14ca193487b888e24194499ee8be2c337afdc89067a23e4cd",
+                    FormatCycle.FIRST);
+            doTestFormat(new JsonFormatter(), "someFile.json",
+                    "c6e19e9d042d8d2045eb17d2966f105e6c538d5c05c614c556eb88dfb020645cb2d410cf059643a14ca193487b888e24194499ee8be2c337afdc89067a23e4cd",
+                    FormatCycle.SECOND);
         }
     }
 
@@ -48,7 +57,7 @@ class JsonFormatterTest extends AbstractFormatterTest {
         JsonFormatter jsonFormatter = new JsonFormatter();
         assertFalse(jsonFormatter.isInitialized());
         jsonFormatter.init(new HashMap<String, String>(),
-                new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+                new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_PRIMARY_DIR));
         assertTrue(jsonFormatter.isInitialized());
     }
 
@@ -65,11 +74,17 @@ class JsonFormatterTest extends AbstractFormatterTest {
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
                     "2122f00ff5a3b4d3012d568b907deaecee248b5b1f8e3ebe213f6b7b3a628ad0c14d236e79789763d940f346c689694ac9854fe8fe7d935a50286e65c036a36d",
-                    LineEnding.CRLF);
+                    LineEnding.CRLF, FormatCycle.FIRST);
+            doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
+                    "2122f00ff5a3b4d3012d568b907deaecee248b5b1f8e3ebe213f6b7b3a628ad0c14d236e79789763d940f346c689694ac9854fe8fe7d935a50286e65c036a36d",
+                    LineEnding.CRLF, FormatCycle.SECOND);
         } else {
             doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
                     "5d433f2700a2fdabfabdb309d5f807df91ad86f7a94658d4a3f2f3699ae78b2efb1de451c141f61905f1c814cd647f312ae9651454e65d124510be0573082e86",
-                    LineEnding.CRLF);
+                    LineEnding.CRLF, FormatCycle.FIRST);
+            doTestFormat(jsonFormattingOptions, new JsonFormatter(), "someFile.json",
+                    "5d433f2700a2fdabfabdb309d5f807df91ad86f7a94658d4a3f2f3699ae78b2efb1de451c141f61905f1c814cd647f312ae9651454e65d124510be0573082e86",
+                    LineEnding.CRLF, FormatCycle.SECOND);
         }
     }
 

--- a/src/test/java/net/revelc/code/formatter/xml/XMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/xml/XMLFormatterTest.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import org.junit.jupiter.api.Test;
 
 import net.revelc.code.formatter.AbstractFormatterTest;
+import net.revelc.code.formatter.FormatCycle;
 
 /**
  * @author yoshiman
@@ -35,10 +36,18 @@ class XMLFormatterTest extends AbstractFormatterTest {
         // default is regardless of requesting it to be CRLF later which is ignored.
         if (System.lineSeparator().equals("\n")) {
             doTestFormat(new XMLFormatter(), "someFile.xml",
-                    "a5bfe48d45504b624d5f610bcbb935b117c8190de7c27957a8ba3658df6f3879682c485d77378443399a5d092899105988386c56b14308ac21faf02a82bfdffb");
+                    "a5bfe48d45504b624d5f610bcbb935b117c8190de7c27957a8ba3658df6f3879682c485d77378443399a5d092899105988386c56b14308ac21faf02a82bfdffb",
+                    FormatCycle.FIRST);
+            doTestFormat(new XMLFormatter(), "someFile.xml",
+                    "a5bfe48d45504b624d5f610bcbb935b117c8190de7c27957a8ba3658df6f3879682c485d77378443399a5d092899105988386c56b14308ac21faf02a82bfdffb",
+                    FormatCycle.SECOND);
         } else {
             doTestFormat(new XMLFormatter(), "someFile.xml",
-                    "1fc08d47972da8debc97ef4071bc1a67a7df588513242e0af8a5df507c469a5921e52f096a436713c2291107ca20e1c215069abcd9dc04bed9ccbcb0418932e0");
+                    "1fc08d47972da8debc97ef4071bc1a67a7df588513242e0af8a5df507c469a5921e52f096a436713c2291107ca20e1c215069abcd9dc04bed9ccbcb0418932e0",
+                    FormatCycle.FIRST);
+            doTestFormat(new XMLFormatter(), "someFile.xml",
+                    "1fc08d47972da8debc97ef4071bc1a67a7df588513242e0af8a5df507c469a5921e52f096a436713c2291107ca20e1c215069abcd9dc04bed9ccbcb0418932e0",
+                    FormatCycle.SECOND);
         }
     }
 
@@ -46,7 +55,8 @@ class XMLFormatterTest extends AbstractFormatterTest {
     void testIsIntialized() throws Exception {
         XMLFormatter xmlFormatter = new XMLFormatter();
         assertFalse(xmlFormatter.isInitialized());
-        xmlFormatter.init(Collections.emptyMap(), new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_DIR));
+        xmlFormatter.init(Collections.emptyMap(),
+                new AbstractFormatterTest.TestConfigurationSource(TEST_OUTPUT_PRIMARY_DIR));
         assertTrue(xmlFormatter.isInitialized());
     }
 


### PR DESCRIPTION
Fixes #523 

Currently we do a single pass of formatting.  This itself does not prove our formatting is actually valid.  We need a second pass that processes the files formatted in the first pass to ensure they result in same output.  This was needed to further track down issue with html processing and also flushed out issue in css processing.