### PR TITLE
[ci] Restore license checking, omit git tasks

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -44,7 +44,7 @@ jobs:
         key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys: ${{ matrix.os }}-m2
     - name: Build with Maven
-      run: mvn -B -V -e "-Dstyle.color=always" verify -D"license.skip=true"
+      run: mvn -B -V -e "-Dstyle.color=always" verify
       env:
         MAVEN_OPTS: -Djansi.force=true
 

--- a/pom.xml
+++ b/pom.xml
@@ -349,13 +349,6 @@
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
           <version>4.1</version>
-          <dependencies>
-            <dependency>
-              <groupId>com.mycila</groupId>
-              <artifactId>license-maven-plugin-git</artifactId>
-              <version>4.1</version>
-            </dependency>
-          </dependencies>
         </plugin>
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
This reverts the change in #529 and restores the processing of licenses
as part of CI tasks. However, drop the optional processing of git
information to populate unused variables for the license header
template.