### PR TITLE
Build for Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,7 +116,10 @@
   <properties>
     <junit.version>5.8.1</junit.version>
 
-    <maven.compiler.release>8</maven.compiler.release>
+    <!-- all 3 are needed, because some plugins might use the source/target variables -->
+    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.source>11</maven.compiler.source>
+    <maven.compiler.target>11</maven.compiler.target>
 
     <!-- skip standard site deployment, because site is deployed using github plugin instead -->
     <maven.site.deploy.skip>true</maven.site.deploy.skip>
@@ -295,16 +298,6 @@
       <groupId>org.w3c.css</groupId>
       <artifactId>sac</artifactId>
       <version>1.3</version>
-    </dependency>
-    <dependency>
-      <!--
-        Needed because jdk11 enforcement of jdk8 compliance is stricter than either
-        Java 11 compliance or jdk8 enforcement of Java 8 compliance.
-      -->
-      <groupId>xml-apis</groupId>
-      <artifactId>xml-apis</artifactId>
-      <!-- versions plugin says 2.0.2 is newer, but that is just a relocation pom to much older version -->
-      <version>1.4.01</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>


### PR DESCRIPTION
Build for Java 11 because JDT dependencies require 11 or later
The plugin won't currently work for versions prior to 11 because of
the dependencies, so this ensures the plugin itself also targets 11.