### PR TITLE
Bump dependencies for Eclipse 2021-12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -167,3 +167,8 @@ ver 2.17.1
 ==========
 - Bump jsdt support to 2021-09 - now requires jdk 11
 - Fix processing on end of line (EOL) markers making it accurate (mixed match resulted in odd behavior)
+
+ver 2.18.0
+==========
+- Support Eclipse 2021-12 (4.22, JDT 3.28) - now requires jdk 11
+

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ versions.
 
 ## JDK Requirements
 - 2.16.x requires jdk 8 as required by Eclipse binaries
-- 2.17.x requires jdk 11 as required by Eclipse binaries
+- 2.17.x and later requires jdk 11 as required by Eclipse binaries
 
 ## Changelog
 

--- a/pom.xml
+++ b/pom.xml
@@ -154,19 +154,19 @@
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.contenttype</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.expressions</artifactId>
-        <version>3.8.0</version>
+        <version>3.8.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.filesystem</artifactId>
-        <version>1.9.100</version>
+        <version>1.9.200</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
@@ -178,49 +178,49 @@
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.resources</artifactId>
-        <version>3.15.100</version>
+        <version>3.16.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.runtime</artifactId>
-        <version>3.23.0</version>
+        <version>3.24.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.app</artifactId>
-        <version>1.6.0</version>
+        <version>1.6.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.common</artifactId>
-        <version>3.15.0</version>
+        <version>3.15.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.preferences</artifactId>
-        <version>3.9.0</version>
+        <version>3.9.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.equinox.registry</artifactId>
-        <version>3.11.0</version>
+        <version>3.11.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.osgi</artifactId>
-        <version>3.17.0</version>
+        <version>3.17.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.team.core</artifactId>
-        <version>3.9.100</version>
+        <version>3.9.200</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
@@ -287,7 +287,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.27.0</version>
+      <version>3.28.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>
@@ -341,12 +341,12 @@
         <plugin>
           <groupId>com.mycila</groupId>
           <artifactId>license-maven-plugin</artifactId>
-          <version>4.1</version>
+          <version>4.2.rc1</version>
         </plugin>
         <plugin>
           <groupId>net.revelc.code.formatter</groupId>
           <artifactId>formatter-maven-plugin</artifactId>
-          <version>2.17.0</version>
+          <version>2.17.1</version>
           <configuration>
             <configFile>${project.basedir}/src/main/resources/formatter-maven-plugin/eclipse/java.xml</configFile>
             <configJsFile>${project.basedir}/src/main/resources/formatter-maven-plugin/eclipse/javascript.xml</configJsFile>

--- a/src/site/markdown/eclipse-versions.md.vm
+++ b/src/site/markdown/eclipse-versions.md.vm
@@ -26,6 +26,7 @@ their compatibility with major Eclipse releases.
 
 formatter-maven-plugin | Eclipse<br/>Name | Eclipse<br/>Version | JDT Core | JDK<br/>Version
 -----------------------|------------------|---------------------|----------|----------------
+2.18                   | 2021-12          | 4.22                | 3.28     | 11
 2.17                   | 2021-09          | 4.21                | 3.27     | 11
 2.16                   | 2021-06          | 4.20                | 3.26     | 8
 2.15                   | 2021-03          | 4.19                | 3.25     | 8


### PR DESCRIPTION
* Bump JDT Core to 3.28
* Bump JDT Core's transitive dependencies
* Update compatibility doc and CHANGELOG