### PR TITLE
[rework] Make sure trailing space removal is counted as formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,4 +171,4 @@ ver 2.17.1
 ver 2.18.0
 ==========
 - Support Eclipse 2021-12 (4.22, JDT 3.28) - now requires jdk 11
-
+- Move whitespace trim to ensure it's counted in formatting stats

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -644,10 +644,12 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         if (!Result.SKIPPED.equals(result)) {
             if (formattedCode == null) {
                 result = Result.FAIL;
-            } else if (originalCode.equals(formattedCode)) {
-                result = Result.SKIPPED;
             } else {
-                result = Result.SUCCESS;
+                // Process the source one more time and remove any trailing whitespace found
+                if (removeTrailingWhitespace) {
+                    formattedCode = REMOVE_TRAILING_PATTERN.matcher(formattedCode).replaceAll("");
+                }
+                result = originalCode.equals(formattedCode) ? Result.SKIPPED : Result.SUCCESS;
             }
         }
 
@@ -659,11 +661,6 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         } else if (Result.FAIL.equals(result)) {
             rc.failCount++;
             return;
-        }
-
-        // Process the source one more time and remove any trailing whitespace found
-        if (removeTrailingWhitespace && formattedCode != null) {
-            formattedCode = REMOVE_TRAILING_PATTERN.matcher(formattedCode).replaceAll("");
         }
 
         // Write the cache


### PR DESCRIPTION
The new whitespace trim logic falls outside the stats block but is still formatting.  Moved this up so that it is included in counts.


notes:
- We don't have tests that perform a true formatting so we should think about adding integration tests at some point using invoker.  I noticed this while working on jsoup as it doesn't hit this logic via the unit tests then realized we were never actually testing this directly.  It works fine, just needs to be in the right spot.
- We should consider making this default behaviour rather than opt in.  Its purpose is to fix bugs with javadoc but at the moment also fixes bugs with jsoup on html (which may end up fixed in jsoup but noting that here).