### PR TITLE
[default] Change remove trailing whitespace default to 'true'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -172,3 +172,4 @@ ver 2.18.0
 ==========
 - Support Eclipse 2021-12 (4.22, JDT 3.28) - now requires jdk 11
 - Move whitespace trim to ensure it's counted in formatting stats
+- Set whitespace trim to default 'true' as it is formatting

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -336,10 +336,13 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
     /**
      * When set to true, remove trailing whitespace on all lines after the formatter has finished.
      *
+     * Default to 'true' since 2.18.0
+     *
      * @since 2.17.0
      */
-    @Parameter(defaultValue = "false", property = "formatter.removeTrailingWhitespace")
+    @Parameter(defaultValue = "true", property = "formatter.removeTrailingWhitespace")
     private boolean removeTrailingWhitespace;
+
     private JavaFormatter javaFormatter = new JavaFormatter();
 
     private JavascriptFormatter jsFormatter = new JavascriptFormatter();


### PR DESCRIPTION
We are formatting, this doesn't make sense to opt into and would result in potentially requiring us to patch jsoup for example and maybe others.