### PR TITLE
Allow all branches to build on actions, use jsoup snapshot 1.15.1, and add repo to allow it

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -17,11 +17,7 @@
 
 name: mvn verify
 
-on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,3 +173,4 @@ ver 2.18.0
 - Support Eclipse 2021-12 (4.22, JDT 3.28) - now requires jdk 11
 - Move whitespace trim to ensure it's counted in formatting stats
 - Set whitespace trim to default 'true' as it is formatting
+- Added support for jsoup maxPaddingWidth, we default to -1 to disable to retain original behaviour on full pretty print

--- a/pom.xml
+++ b/pom.xml
@@ -292,7 +292,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.13.1</version>
+      <version>1.15.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.w3c.css</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,20 @@
     </snapshotRepository>
   </distributionManagement>
 
+  <!-- TODO: Allow pull from snapshots while on jsoup snapshot, remove once finalized -->
+  <repositories>
+    <repository>
+      <id>oss.sonatype.org-snapshot</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
+
   <properties>
     <junit.version>5.8.2</junit.version>
 

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -45,6 +45,7 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
         formatter.charset(Charset.forName(options.getOrDefault("charset", StandardCharsets.UTF_8.name())));
         formatter.escapeMode(EscapeMode.valueOf(options.getOrDefault("escapeMode", EscapeMode.xhtml.name())));
         formatter.indentAmount(Integer.parseInt(options.getOrDefault("indentAmount", "4")));
+        formatter.maxPaddingWidth(Integer.parseInt(options.getOrDefault("maxPaddingWidth", "-1")));
         formatter.outline(Boolean.parseBoolean(options.getOrDefault("outlineMode", Boolean.TRUE.toString())));
         formatter.prettyPrint(Boolean.parseBoolean(options.getOrDefault("pretty", Boolean.TRUE.toString())));
         formatter.syntax(Syntax.valueOf(options.getOrDefault("syntax", Syntax.html.name())));

--- a/src/main/resources/formatter-maven-plugin/jsoup/html.properties
+++ b/src/main/resources/formatter-maven-plugin/jsoup/html.properties
@@ -18,6 +18,7 @@
 charset=UTF-8
 escapeMode=xhtml
 indentAmount=4
+maxPaddingWidth=-1
 outlineMode=true
 pretty=true
 syntax=html

--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -31,8 +31,8 @@ class HTMLFormatterTest extends AbstractFormatterTest {
     void testDoFormatFile() throws Exception {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         String expectedHash = LineEnding.LF.isSystem()
-                ? "1cfe5e48635d8618be4d490a5e7f690ef8e1dfc7e24303457030e281068bbebac44b552ae52ac88f03bf10e72ed0582904d665afc54bade395fd3d183abe0cba"
-                : "ef3969324f673d0831fe3a7c36426d162d0619b9dcdc187e5674b41a9743fdb9bad10a651f66dd43ff0806d1b1303bfb0384375f12bf1940e84347b84846b631";
+                ? "a342e3aa371fe0188144b7efae2c5f92c66966b08c2f816f9d91966a58b1f2270b1ac79a24ae19709af26cd9b4eeca868469870977854b42e04477d04a951cc4"
+                : "1ca6c6d7569344583700a37b24b613b28d12a4a658b28953892503a067ab0c2fcbbbe128f8143ec7c8c6aca65ec14eff63555f9bbc661b60c0945ce596dcc44d";
         LineEnding lineEnding = LineEnding.LF.isSystem() ? LineEnding.LF : LineEnding.CRLF;
         singlePassTest(new HTMLFormatter(), "someFile.html", expectedHash, lineEnding);
         // TODO: jsoup has further bugs to fix so this always fails currently


### PR DESCRIPTION
hashes are slightly different as it changes 3 lines to have ending tag </ending> instead of />.   It does improve what appears to have been a double header getting added.  Will keep this setup this way for a bit while testing out more localized items including a temp code patch that will be coming here so our tests work while jsoup is working out why they don't trim properly so I can turn on dual tests here during further testing.