### PR TITLE
[oss] Remove author not a good indicator of who is editing files and...

### DIFF
--- a/src/main/java/net/revelc/code/formatter/AbstractCacheableFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/AbstractCacheableFormatter.java
@@ -27,7 +27,6 @@ import net.revelc.code.formatter.html.HTMLFormatter;
 import net.revelc.code.formatter.xml.XMLFormatter;
 
 /**
- * @author marvin.froeder
  */
 public abstract class AbstractCacheableFormatter {
 

--- a/src/main/java/net/revelc/code/formatter/ConfigurationSource.java
+++ b/src/main/java/net/revelc/code/formatter/ConfigurationSource.java
@@ -19,7 +19,6 @@ import java.nio.charset.Charset;
 import org.apache.maven.plugin.logging.Log;
 
 /**
- * @author marvin.froeder
  */
 public interface ConfigurationSource {
 

--- a/src/main/java/net/revelc/code/formatter/Formatter.java
+++ b/src/main/java/net/revelc/code/formatter/Formatter.java
@@ -17,7 +17,6 @@ import java.io.File;
 import java.util.Map;
 
 /**
- * @author marvin.froeder
  */
 public interface Formatter {
 

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -73,10 +73,6 @@ import net.revelc.code.formatter.xml.XMLFormatter;
  * Mojo parameters allow customizing formatting by specifying the config XML file, line endings, compiler version, and
  * source code locations. Reformatting source files is avoided using an sha512 hash of the content, comparing to the
  * original hash to the hash after formatting and a cached hash.
- * 
- * @author jecki
- * @author Matt Blanchette
- * @author marvin.froeder
  */
 @Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = true, threadSafe = true)
 public class FormatterMojo extends AbstractMojo implements ConfigurationSource {

--- a/src/main/java/net/revelc/code/formatter/LineEnding.java
+++ b/src/main/java/net/revelc/code/formatter/LineEnding.java
@@ -14,7 +14,6 @@
 package net.revelc.code.formatter;
 
 /**
- * @author marvin.froeder
  */
 public enum LineEnding {
 

--- a/src/main/java/net/revelc/code/formatter/Result.java
+++ b/src/main/java/net/revelc/code/formatter/Result.java
@@ -14,7 +14,6 @@
 package net.revelc.code.formatter;
 
 /**
- * @author marvin.froeder
  */
 public enum Result {
     SKIPPED, SUCCESS, FAIL

--- a/src/main/java/net/revelc/code/formatter/ValidateMojo.java
+++ b/src/main/java/net/revelc/code/formatter/ValidateMojo.java
@@ -28,8 +28,6 @@ import org.eclipse.jface.text.BadLocationException;
  * This mojo is very similar to Formatter mojo, but it is focused on CI servers.
  * 
  * If the code ain't formatted as expected this mojo will fail the build
- * 
- * @author marvin.froeder
  */
 @Mojo(name = "validate", defaultPhase = LifecyclePhase.VALIDATE, requiresProject = true, threadSafe = true)
 public class ValidateMojo extends FormatterMojo {

--- a/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
@@ -30,7 +30,6 @@ import net.revelc.code.formatter.Formatter;
 import net.revelc.code.formatter.LineEnding;
 
 /**
- * @author yoshiman
  *
  */
 public class CssFormatter extends AbstractCacheableFormatter implements Formatter {

--- a/src/main/java/net/revelc/code/formatter/html/HTMLFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/html/HTMLFormatter.java
@@ -17,7 +17,6 @@ import net.revelc.code.formatter.Formatter;
 import net.revelc.code.formatter.jsoup.JsoupBasedFormatter;
 
 /**
- * @author yoshiman
  */
 public class HTMLFormatter extends JsoupBasedFormatter implements Formatter {
 

--- a/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
@@ -29,7 +29,6 @@ import net.revelc.code.formatter.Formatter;
 import net.revelc.code.formatter.LineEnding;
 
 /**
- * @author yoshiman
  *
  */
 public class JsonFormatter extends AbstractCacheableFormatter implements Formatter {

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -30,7 +30,6 @@ import net.revelc.code.formatter.Formatter;
 import net.revelc.code.formatter.LineEnding;
 
 /**
- * @author yoshiman
  *
  */
 public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter implements Formatter {

--- a/src/main/java/net/revelc/code/formatter/model/ConfigReadException.java
+++ b/src/main/java/net/revelc/code/formatter/model/ConfigReadException.java
@@ -16,8 +16,6 @@ package net.revelc.code.formatter.model;
 /**
  * An exception thrown when there is an error reading settings from the code formatter profile of an Eclipse formatter
  * config file.
- * 
- * @author Matt Blanchette
  */
 public class ConfigReadException extends Exception {
 

--- a/src/main/java/net/revelc/code/formatter/model/ConfigReader.java
+++ b/src/main/java/net/revelc/code/formatter/model/ConfigReader.java
@@ -23,9 +23,6 @@ import org.xml.sax.SAXException;
 
 /**
  * This class reads a config file for Eclipse code formatter.
- * 
- * @author jecki
- * @author Matt Blanchette
  */
 public class ConfigReader {
 

--- a/src/main/java/net/revelc/code/formatter/model/Profile.java
+++ b/src/main/java/net/revelc/code/formatter/model/Profile.java
@@ -19,8 +19,6 @@ import java.util.Map;
 /**
  * A class representing the profile XML element in the Eclipse formatter config file, including the kind attribute and
  * Map of setting id and value.
- * 
- * @author Matt Blanchette
  */
 public class Profile {
 

--- a/src/main/java/net/revelc/code/formatter/model/Profiles.java
+++ b/src/main/java/net/revelc/code/formatter/model/Profiles.java
@@ -20,8 +20,6 @@ import java.util.Map;
 /**
  * A class representing the profiles XML element in the Eclipse formatter config file, including a List of profile
  * setting Maps with id and value.
- * 
- * @author Matt Blanchette
  */
 public class Profiles {
 

--- a/src/main/java/net/revelc/code/formatter/model/RuleSet.java
+++ b/src/main/java/net/revelc/code/formatter/model/RuleSet.java
@@ -18,9 +18,6 @@ import org.apache.commons.digester3.RuleSetBase;
 
 /**
  * An Apache Commons Digester RuleSet for configuring a digester to parse the Eclipse formatter config XML into objects.
- * 
- * @author jecki
- * @author Matt Blanchette
  */
 class RuleSet extends RuleSetBase {
 

--- a/src/main/java/net/revelc/code/formatter/model/Setting.java
+++ b/src/main/java/net/revelc/code/formatter/model/Setting.java
@@ -16,8 +16,6 @@ package net.revelc.code.formatter.model;
 /**
  * A class representing the setting XML element in the Eclipse formatter config file, including the id and value
  * attributes.
- * 
- * @author Matt Blanchette
  */
 public class Setting {
 

--- a/src/main/java/net/revelc/code/formatter/xml/XMLFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/XMLFormatter.java
@@ -23,8 +23,6 @@ import net.revelc.code.formatter.xml.lib.FormattingPreferences;
 import net.revelc.code.formatter.xml.lib.XmlDocumentFormatter;
 
 /**
- * @author yoshiman
- * @author jam01
  */
 public class XMLFormatter extends AbstractCacheableFormatter implements Formatter {
     private XmlDocumentFormatter formatter;

--- a/src/test/java/net/revelc/code/formatter/LineEndingTest.java
+++ b/src/test/java/net/revelc/code/formatter/LineEndingTest.java
@@ -19,9 +19,6 @@ import org.junit.jupiter.api.Test;
 
 /**
  * Test class for {@link LineEnding}.
- * 
- * @author Matt Blanchette
- * @author marvin.froeder
  */
 class LineEndingTest {
 

--- a/src/test/java/net/revelc/code/formatter/css/CssFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/css/CssFormatterTest.java
@@ -23,7 +23,6 @@ import net.revelc.code.formatter.AbstractFormatterTest;
 import net.revelc.code.formatter.LineEnding;
 
 /**
- * @author yoshiman
  */
 class CssFormatterTest extends AbstractFormatterTest {
 

--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -23,7 +23,6 @@ import net.revelc.code.formatter.AbstractFormatterTest;
 import net.revelc.code.formatter.LineEnding;
 
 /**
- * @author yoshiman
  */
 class HTMLFormatterTest extends AbstractFormatterTest {
 

--- a/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/java/JavaFormatterTest.java
@@ -23,7 +23,6 @@ import net.revelc.code.formatter.AbstractFormatterTest;
 import net.revelc.code.formatter.LineEnding;
 
 /**
- * @author marvin.froeder
  */
 class JavaFormatterTest extends AbstractFormatterTest {
 

--- a/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/json/JsonFormatterTest.java
@@ -26,7 +26,6 @@ import net.revelc.code.formatter.AbstractFormatterTest;
 import net.revelc.code.formatter.LineEnding;
 
 /**
- * @author yoshiman
  */
 class JsonFormatterTest extends AbstractFormatterTest {
 

--- a/src/test/java/net/revelc/code/formatter/model/ConfigReaderTest.java
+++ b/src/test/java/net/revelc/code/formatter/model/ConfigReaderTest.java
@@ -25,9 +25,6 @@ import org.xml.sax.SAXException;
 
 /**
  * Test class for {@link ConfigReader}.
- * 
- * @author jecki
- * @author Matt Blanchette
  */
 class ConfigReaderTest {
 

--- a/src/test/java/net/revelc/code/formatter/xml/XMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/xml/XMLFormatterTest.java
@@ -23,8 +23,6 @@ import net.revelc.code.formatter.AbstractFormatterTest;
 import net.revelc.code.formatter.LineEnding;
 
 /**
- * @author yoshiman
- * @author jam01
  */
 class XMLFormatterTest extends AbstractFormatterTest {
 


### PR DESCRIPTION
…not very open source friendly

GIT provides this information so it is not needed here.  A lot of these are unable to even know who the author is and over time it becomes impossible to know if the source is what author really wrote and many times indicates blame.  The GIT data is a far better indicator of the author and how to find the author that donated code under open license.  This was further not actually being added outside of these cases making repo inconsistent.