### PR TITLE
[jsoup] Add an internal patch to trim trailing whitespace so our tests work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,3 +175,4 @@ ver 2.18.0
 - Set whitespace trim to default 'true' as it is formatting
 - Added support for jsoup maxPaddingWidth, we default to -1 to disable to retain original behaviour on full pretty print
 - Add <script> block to html tests to demonstrate upstream jsoup bug adding new lines has been fixed
+- Add support for trimming trailing spaces from jsoup pretty print so our internal tests can function properly due to jsoup upstream issues

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -16,6 +16,7 @@ package net.revelc.code.formatter.jsoup;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
@@ -33,6 +34,9 @@ import net.revelc.code.formatter.LineEnding;
  * The Class JsoupBasedFormatter.
  */
 public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter implements Formatter {
+
+    /** The Constant REMOVE_TRAILING_PATTERN. */
+    private static final Pattern REMOVE_TRAILING_PATTERN = Pattern.compile("\\p{Blank}+$", Pattern.MULTILINE);
 
     /** The formatter. */
     private OutputSettings formatter;
@@ -60,7 +64,12 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
         document = Jsoup.parse(code, "", Parser.htmlParser());
         document.outputSettings(this.formatter);
 
-        final var formattedCode = document.outerHtml();
+        var formattedCode = document.outerHtml();
+
+        // TODO: Fixing trailing space issue caused by jsoup. We do fix this during a proper run
+        // but our tests fail to do so thus we are duplicating this until jsoup fixes bug.
+        formattedCode = REMOVE_TRAILING_PATTERN.matcher(formattedCode).replaceAll("");
+
         if (code.equals(formattedCode)) {
             return null;
         }

--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -36,11 +36,11 @@ class HTMLFormatterTest extends AbstractFormatterTest {
     void testDoFormatFile() throws Exception {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         final var expectedHash = LineEnding.LF.isSystem()
-                ? "ca14768f37dab92f65551a71fb3e4ce1304df2f9528ec24abeeb615aea2fc1b3f8910b823e24f4a391b58bddc555429761520f7cb43f0bccb51f04f04b789aab"
-                : "563119044ad9aaa712080e7261653f883b4c10a3376a8546200db3ac984233fb82fa012be4e08277d11402098b43c1b28f216393647cc8cbb6213b0023433469";
+                ? "9774ef68195bb7bd9c1d0eaed6b3c7536633d0d916ad52187005ec2c89e0fcfe42e14dd4576453cb14abaef0352ef0b7a275c015e7cc124b8b4da481f423d030"
+                : "135d87e3e4be25a31bfc360a049cc41217a8ad8e2e697fb9b423f48cba08789b12134503b2e44d661eb2a54adc47e0530b661be2ee0e4589ef306986c04f2933";
         final var lineEnding = LineEnding.LF.isSystem() ? LineEnding.LF : LineEnding.CRLF;
         this.singlePassTest(new HTMLFormatter(), "someFile.html", expectedHash, lineEnding);
-        // TODO: jsoup has further bugs to fix so this always fails currently
+        // TODO: jsoup has further bugs to fix so this always fails currently as their counter for leading space is sometimes wrong (off by one)
         // twoPassTest(emptyMap(), new HTMLFormatter(), "someFile.html", expectedHash, lineEnding);
     }
 


### PR DESCRIPTION
Technically this one is a duplicate due to lack of our tests running in full and picking up the javadoc patch that does same.  In order to try to move this forwards, this is in here with a // TODO so we can remove it later when Jsoup fixes issue.  I have reported it, they stated fixed, I reported still broken, was told they would look more but heard nothing back.  So for now I'm giving up to get this in place.