### PR TITLE
Fix joup counting issue.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -175,4 +175,4 @@ ver 2.18.0
 - Set whitespace trim to default 'true' as it is formatting
 - Added support for jsoup maxPaddingWidth, we default to -1 to disable to retain original behaviour on full pretty print
 - Add <script> block to html tests to demonstrate upstream jsoup bug adding new lines has been fixed
-- Add support for trimming trailing spaces from jsoup pretty print so our internal tests can function properly due to jsoup upstream issues
+- Add support for trimming trailing spaces from jsoup pretty print so our internal tests can function properly due to jsoup upstream bug

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,3 +176,4 @@ ver 2.18.0
 - Added support for jsoup maxPaddingWidth, we default to -1 to disable to retain original behaviour on full pretty print
 - Add <script> block to html tests to demonstrate upstream jsoup bug adding new lines has been fixed
 - Add support for trimming trailing spaces from jsoup pretty print so our internal tests can function properly due to jsoup upstream bug
+- Add support for counting leading spaces from jsoup pretty print so our internal tests can function property due to jsoup upstream bug

--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -36,8 +36,8 @@ class HTMLFormatterTest extends AbstractFormatterTest {
     void testDoFormatFile() throws Exception {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         final var expectedHash = LineEnding.LF.isSystem()
-                ? "9774ef68195bb7bd9c1d0eaed6b3c7536633d0d916ad52187005ec2c89e0fcfe42e14dd4576453cb14abaef0352ef0b7a275c015e7cc124b8b4da481f423d030"
-                : "135d87e3e4be25a31bfc360a049cc41217a8ad8e2e697fb9b423f48cba08789b12134503b2e44d661eb2a54adc47e0530b661be2ee0e4589ef306986c04f2933";
+                ? "eaf4db207cdb232d1242c88d5d2e56357d48d717968a89e383771136a1315d8da876ada06e30bb4feb266ea9f0cf184535bb6f0ffd12d8d60a34744d4107a2e1"
+                : "fc0b6d7ed8de398408a4c02c4af61ad205a98321933c868d1d61376756d15ce55f3ce397a8e306e20c10cee4064c5bad9a4bb939e27ed751ad8c60eef1916cf7";
         final var lineEnding = LineEnding.LF.isSystem() ? LineEnding.LF : LineEnding.CRLF;
         this.twoPassTest(Collections.emptyMap(), new HTMLFormatter(), "someFile.html", expectedHash, lineEnding);
     }

--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -39,9 +39,7 @@ class HTMLFormatterTest extends AbstractFormatterTest {
                 ? "9774ef68195bb7bd9c1d0eaed6b3c7536633d0d916ad52187005ec2c89e0fcfe42e14dd4576453cb14abaef0352ef0b7a275c015e7cc124b8b4da481f423d030"
                 : "135d87e3e4be25a31bfc360a049cc41217a8ad8e2e697fb9b423f48cba08789b12134503b2e44d661eb2a54adc47e0530b661be2ee0e4589ef306986c04f2933";
         final var lineEnding = LineEnding.LF.isSystem() ? LineEnding.LF : LineEnding.CRLF;
-        this.singlePassTest(new HTMLFormatter(), "someFile.html", expectedHash, lineEnding);
-        // TODO: jsoup has further bugs to fix so this always fails currently as their counter for leading space is sometimes wrong (off by one)
-        // twoPassTest(emptyMap(), new HTMLFormatter(), "someFile.html", expectedHash, lineEnding);
+        this.twoPassTest(Collections.emptyMap(), new HTMLFormatter(), "someFile.html", expectedHash, lineEnding);
     }
 
     /**


### PR DESCRIPTION
Jsoup fails to count their indenting properly.  While they have a website to send test data for them to review they do not expose all the parameters.  So anything with 1 character indent is fine.  Its all the other indents that have issues.  The first commit here can be ran on its own still in single test mode then look at resulting second html page.  It will get extra 1 character on quite a number of lines.  Typically those are tag breaks with data on the second line.  This fix iteslf is extermely ugly but resolve the issue which I don't think jsoup is going to resolve.  They closed my original ticket stating fixed but I asked to reopen as not fixed.  They said they were looking but that was first week in November so nothing since and we are on the latest snapshot.  So like the others around jsoup fixing what they have failed to fix with hopes one day we remove this code.