### PR TITLE
Add sort and removal of timestamp from cache file for fuller automation / repeatability / First integration test

### DIFF
--- a/.github/workflows/it.yaml
+++ b/.github/workflows/it.yaml
@@ -1,0 +1,43 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Java Integration Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest, windows-latest]
+        java: [11, 17]
+      fail-fast: false
+      max-parallel: 4
+    name: Integration Tests
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v2
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: zulu
+      - name: Build Setup
+        run: mvn clean install
+      - name: Integration Test with Maven
+        run: mvn -Prun-it clean install -B
+      - name: My backup step
+        if: ${{ failure() }}
+        run: grep "" /home/runner/work/formatter-maven-plugin/formatter-maven-plugin/target/it/cache/build.log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -182,3 +182,4 @@ ver 2.18.0
 - Internal usage of http: has been switched to https and any redirects from old google code were updated to reflect this repo as seen in tests.  One left over http is a bogus site.
 - Enhance cache support to not write timestamp to it and to sort content making it safe to check in and use via automation to update when using cross platform such as linux and windows.
   Without this, it can get random data write as this is read into memory first then written at end with no guarantee of order.
+- Added first integration test to confirm caching with sorting and removal of timestamp can be confirmed properly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -180,3 +180,5 @@ ver 2.18.0
 - Add support for breaking '--><! from jsoup pretty print so our internal tests can function propertly due to jsoup upstream bug
 - Run overall code cleanup including using java 10 'var' since we require jdk 11 to work.
 - Internal usage of http: has been switched to https and any redirects from old google code were updated to reflect this repo as seen in tests.  One left over http is a bogus site.
+- Enhance cache support to not write timestamp to it and to sort content making it safe to check in and use via automation to update when using cross platform such as linux and windows.
+  Without this, it can get random data write as this is read into memory first then written at end with no guarantee of order.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ basis for this plugin's formatting. See [the project website][compat] for a
 list of recent versions of this plugin and their corresponding Eclipse
 versions.
 
+## Integration Tests ##
+
+mvn -Prun-it clean install
+
 ## JDK Requirements
 - 2.16.x requires jdk 8 as required by Eclipse binaries
 - 2.17.x and later requires jdk 11 as required by Eclipse binaries

--- a/pom.xml
+++ b/pom.xml
@@ -848,5 +848,36 @@
         </pluginManagement>
       </build>
     </profile>
+    <profile>
+      <id>run-it</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-invoker-plugin</artifactId>
+            <version>3.2.2</version>
+            <executions>
+              <execution>
+                <id>integration-test-run</id>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <projectsDirectory>${project.basedir}/src/it</projectsDirectory>
+                  <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
+                  <showVersion>true</showVersion>
+                  <pomIncludes>
+                    <pomInclude>*/pom.xml</pomInclude>
+                  </pomIncludes>
+                  <postBuildHookScript>verify</postBuildHookScript>
+                  <localRepositoryPath>${project.build.directory}/local-repo</localRepositoryPath>
+                  <settingsFile>${project.basedir}/src/it/settings.xml</settingsFile>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 </project>

--- a/src/it/cache/invoker.properties
+++ b/src/it/cache/invoker.properties
@@ -1,0 +1,21 @@
+#
+# Copyright 2010-2017. All work is copyrighted to their respective
+# author(s), unless otherwise stated.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+invoker.goals = clean install -X -D"maven.javadoc.skip=true"
+
+# The expected result of the build, possible values are "success" (default) and "failure"
+invoker.buildResult = success

--- a/src/it/cache/pom.xml
+++ b/src/it/cache/pom.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.github.hazendaz</groupId>
+        <artifactId>base-parent</artifactId>
+        <version>31</version>
+    </parent>
+
+    <groupId>net.revelc.code.formatter</groupId>
+    <artifactId>cache-sample</artifactId>
+    <version>testing</version>
+
+    <name>cache-sample</name>
+    <description>Cache Sample Integration Test</description>
+    <url>https://github.com/revelc/formatter-maven-plugin</url>
+
+    <scm>
+        <connection>scm:git:https://github.com/revelc/formatter-maven-plugin.git</connection>
+        <developerConnection>scm:git:git@github.com/revelc/formatter-maven-plugin.git</developerConnection>
+        <tag>HEAD</tag>
+        <url>https://github.com/revelc/formatter-maven-plugin</url>
+    </scm>
+
+    <build>
+        <finalName>cache-sample</finalName>
+        <plugins>
+            <plugin>
+                <groupId>net.revelc.code.formatter</groupId>
+                <artifactId>formatter-maven-plugin</artifactId>
+                <version>@pom.version@</version>
+                <dependencies>
+                    <dependency>
+                        <groupId>com.github.hazendaz</groupId>
+                        <artifactId>build-tools</artifactId>
+                        <version>1.2.6</version>
+                    </dependency>
+                </dependencies>
+                <executions>
+                    <execution>
+                        <id>format-code</id>
+                        <goals>
+                            <goal>format</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/src/it/cache/src/main/java/net/revelc/code/formatter/cache/CacheSample.java
+++ b/src/it/cache/src/main/java/net/revelc/code/formatter/cache/CacheSample.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazendaz.maven.makeself;
+
+/**
+ * The Class CacheSample.
+ */
+public class CacheSample {
+
+}

--- a/src/it/cache/src/main/java/net/revelc/code/formatter/cache/CacheSample2.java
+++ b/src/it/cache/src/main/java/net/revelc/code/formatter/cache/CacheSample2.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazendaz.maven.makeself;
+
+/**
+ * The Class CacheSample2.
+ */
+public class CacheSample2 {
+
+}

--- a/src/it/cache/src/main/java/net/revelc/code/formatter/cache/CacheSample3.java
+++ b/src/it/cache/src/main/java/net/revelc/code/formatter/cache/CacheSample3.java
@@ -1,0 +1,21 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hazendaz.maven.makeself;
+
+/**
+ * The Class CacheSample3.
+ */
+public class CacheSample3 {
+
+}

--- a/src/it/cache/src/main/java/net/revelc/code/formatter/cache/package-info.java
+++ b/src/it/cache/src/main/java/net/revelc/code/formatter/cache/package-info.java
@@ -1,0 +1,17 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * CacheSample Package Info
+ */
+package net.revelc.code.formatter.cache;

--- a/src/it/cache/verify.groovy
+++ b/src/it/cache/verify.groovy
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+println '*****************************'
+println 'Checking Sample Cache Created'
+println '*****************************'
+println ''
+
+File cache = new File(basedir, "target/formatter-maven-cache.properties")
+assert cache.exists()
+
+println '*********************************'
+println 'Checking Sample Build Log Created'
+println '*********************************'
+println ''
+
+File buildlog = new File(basedir, 'build.log')
+assert buildlog.exists()
+
+println '*********************************'
+println 'Checking Build Log was successful'
+println '*********************************'
+println ''
+
+assert buildlog.text.contains("[INFO] BUILD SUCCESS")
+
+println '*****************************************'
+println 'Checking Number of cache files is correct'
+println '*****************************************'
+println ''
+
+assert !cache.text.contains("#")

--- a/src/it/settings.xml
+++ b/src/it/settings.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+         https://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+-->
+<settings>
+     <profiles>
+          <profile>
+               <id>it-repo</id>
+               <activation>
+                    <activeByDefault>true</activeByDefault>
+               </activation>
+               <repositories>
+                    <repository>
+                         <id>local.central</id>
+                         <url>@localRepositoryUrl@</url>
+                         <releases>
+                              <enabled>true</enabled>
+                         </releases>
+                         <snapshots>
+                              <enabled>true</enabled>
+                         </snapshots>
+                    </repository>
+               </repositories>
+               <pluginRepositories>
+                    <pluginRepository>
+                         <id>local.central</id>
+                         <url>@localRepositoryUrl@</url>
+                         <releases>
+                              <enabled>true</enabled>
+                         </releases>
+                         <snapshots>
+                              <enabled>true</enabled>
+                         </snapshots>
+                    </pluginRepository>
+               </pluginRepositories>
+          </profile>
+     </profiles>
+</settings>


### PR DESCRIPTION
- Sort and removal of timestamp do not appear to delay processing enough right now to warrant adding more if caching is being used.  Can follow up if we have more data to show that has any substantial impact.
- Sort and timestamp ensure that any unexpected write of file will not change the file if nothing changed.  This is prominant on maven plugins with help mojo as maven sets that in generated sources which is then picked up by formatting then promptly is moved by maven after plugin-plugin run.  This behaviour causes the current protections to see that formatting occurred and as such write the cache.  The cache itself is a properties file so it suffers from two major issues.  The first being the timestamp is added everytime it is written which is problematic at best and cannot be disabled (at least last confirmed at jdk 8, did not check to see if we have any new feature to skip that).  The second is that property file is just a hashtable and that is not deterministic on how it will even write the file.  Thus sorting it and removing the timestamp will ensure in such a case we don't have this issue.  It will further help if someone is saving the cache and needs to look at it since all will be ordered nicely.
- The first integration test and associated github action runs this against both jdk 11 and 17.  We should be doing same with general maven but this will cover that.  The users of library need to know this isn't going to break on higher jdks and at very least our lowest support.