### PR TITLE
Provide actionable error message when validation fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -303,6 +303,12 @@
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
+      <artifactId>maven-core</artifactId>
+      <version>3.3.9</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>3.8.4</version>
       <scope>provided</scope>

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -75,8 +75,10 @@ import net.revelc.code.formatter.xml.XMLFormatter;
  * source code locations. Reformatting source files is avoided using an sha512 hash of the content, comparing to the
  * original hash to the hash after formatting and a cached hash.
  */
-@Mojo(name = "format", defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = true, threadSafe = true)
+@Mojo(name = FormatterMojo.FORMAT_MOJO_NAME, defaultPhase = LifecyclePhase.PROCESS_SOURCES, requiresProject = true, threadSafe = true)
 public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
+
+    static final String FORMAT_MOJO_NAME = "format";
 
     /** The Constant CACHE_PROPERTIES_FILENAME. */
     private static final String CACHE_PROPERTIES_FILENAME = "formatter-maven-cache.properties";

--- a/src/main/java/net/revelc/code/formatter/ValidateMojo.java
+++ b/src/main/java/net/revelc/code/formatter/ValidateMojo.java
@@ -83,7 +83,7 @@ public class ValidateMojo extends FormatterMojo {
             throw new MojoFailureException(errorMessage);
         }
         if (rc.failCount != 0) {
-            throw new MojoExecutionException("Error formating '" + file + "' ");
+            throw new MojoExecutionException("Error formatting '" + file + "' ");
         }
     }
 


### PR DESCRIPTION
This plugin is used extensively in Quarkus and new contributors
are often left unsure of what to do when they see the validation
error message.
This change provides users with an explicit command to run when the
validation fails