### PR TITLE
[tests] Add a test for showing bug in json formatter.

### DIFF
--- a/src/test/java/net/revelc/code/formatter/json/NormalJsonFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/json/NormalJsonFormatterTest.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package net.revelc.code.formatter.json;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.Objects;
+
+import net.revelc.code.formatter.AbstractFormatterTest;
+import net.revelc.code.formatter.LineEnding;
+import org.codehaus.plexus.util.IOUtil;
+import org.codehaus.plexus.util.StringUtils;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class NormalJsonFormatterTest extends AbstractFormatterTest {
+
+    @Test
+    void test() throws IOException {
+        final var jsonFormatter = new JsonFormatter();
+        Assertions.assertFalse(jsonFormatter.isInitialized());
+        jsonFormatter.init(Collections.emptyMap(),
+                new TestConfigurationSource(AbstractFormatterTest.TEST_OUTPUT_PRIMARY_DIR));
+        Assertions.assertTrue(jsonFormatter.isInitialized());
+
+        String beforeString = null;
+        try (InputStream inputStream = this.getClass().getResourceAsStream("/normal-json/before.json")) {
+            beforeString = IOUtil.toString(Objects.requireNonNull(inputStream), "UTF-8");
+        }
+
+        String afterString = null;
+        try (InputStream inputStream = this.getClass().getResourceAsStream("/normal-json/after.json")) {
+            afterString = IOUtil.toString(Objects.requireNonNull(inputStream), "UTF-8");
+        }
+
+        {
+            String result = jsonFormatter.doFormat(beforeString, LineEnding.CRLF);
+            Assertions.assertEquals(
+                    afterString.replaceAll(LineEnding.LF.getChars(), LineEnding.CRLF.getChars()),
+                    result
+            );
+        }
+
+        {
+            String result = jsonFormatter.doFormat(beforeString, LineEnding.LF);
+            Assertions.assertEquals(
+                    afterString.replaceAll(LineEnding.CRLF.getChars(), LineEnding.LF.getChars()),
+                    result
+            );
+        }
+
+    }
+
+}

--- a/src/test/resources/normal-json/after.json
+++ b/src/test/resources/normal-json/after.json
@@ -1,0 +1,5 @@
+{
+    "name" : "Bob",
+    "age" : 28,
+    "prefer" : 1
+}

--- a/src/test/resources/normal-json/before.json
+++ b/src/test/resources/normal-json/before.json
@@ -1,0 +1,1 @@
+{"name" : "Bob", "age" : 28, "prefer":1}


### PR DESCRIPTION
Hi.

This is just for showing the bug we found.

![image](https://user-images.githubusercontent.com/17455337/153478494-1e182f77-1d9f-42d8-91fe-465990a73f7a.png)

although we use LineEnding.LF, it still contains CRLF in the output when we run it on windows.
