### PR TITLE
[draft] Solution for issue 270 to show all validation errors

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -733,8 +733,11 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             return;
         }
 
-        // Now write the file
-        if (!dryRun) {
+        // Now write the file or log during dry run
+        if (dryRun) {
+            String errorMessage = String.format("File '%s' has not been previously formatted.", file);
+            this.getLog().error(errorMessage);
+        } else {
             this.writeStringToFile(formattedCode, file);
         }
     }


### PR DESCRIPTION
Initial attempt at fixing #270.  This is draft to gather input for feedback of supporting this feature.  It does not have an integration test but steps to test are below.

To test
- Checkout branch
- Run build to generate local snapshot for test usage
- Add extra spacing to 2 or more files
- Run 'mvn net.revelc.code.formatter:formatter-maven-plugin:2.20.0-SNAPSHOT:validate' which will show new behavior of split from output of first file detected that violates formatting rules.
- Run `mvn net.revelc.code.formatter:formatter-maven-plugin:2.20.0-SNAPSHOT:validate -D"formatter.failOnFirstValidationError=false"` which will show multiple files in violation.