### PR TITLE
Jsoup follow-up formatting patches

### DIFF
--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -77,18 +77,20 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
 
         // XXX: Fixing jsoup counter issue when more than one character indentation until jsoup fixes bug.
         if (this.formatter.indentAmount() > 1) {
-            int lineSize;
-            int newLineSize;
+            int lineLength;
+            int trimLineLength;
             int remainder;
             // jsoup can have mixed line ending content
             String[] lines = formattedCode.split("\\r?\\n");
             List<String> newLines = new ArrayList<>(lines.length);
             for (String line : lines) {
-                lineSize = line.length();
-                if (lineSize != 0) {
-                    newLineSize = RESET_LEADING_SPACES_PATTERN.matcher(line).replaceAll("").length();
-                    if (lineSize != newLineSize) {
-                        remainder = (lineSize - newLineSize) % this.formatter.indentAmount();
+                lineLength = line.length();
+                if (lineLength != 0) {
+                    // Trim leading spaces to get trimmed length
+                    trimLineLength = RESET_LEADING_SPACES_PATTERN.matcher(line).replaceAll("").length();
+                    if (lineLength != trimLineLength) {
+                        // Find remainder to correct formatted line
+                        remainder = (lineLength - trimLineLength) % this.formatter.indentAmount();
                         if (remainder > 0) {
                             line = line.substring(remainder);
                         }

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -80,7 +80,7 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
             int lineLength;
             int trimLineLength;
             int remainder;
-            // jsoup can have mixed line ending content
+            // jsoup processing results in mixed line ending content
             String[] lines = formattedCode.split("\\r?\\n");
             List<String> newLines = new ArrayList<>(lines.length);
             for (String line : lines) {

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -71,16 +71,16 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
 
         var formattedCode = document.outerHtml();
 
-        // TODO: Fixing trailing space issue caused by jsoup. We do fix this during a proper run
+        // XXX: Fixing trailing space issue caused by jsoup. We do fix this during a proper run
         // but our tests fail to do so thus we are duplicating this until jsoup fixes bug.
         formattedCode = REMOVE_TRAILING_PATTERN.matcher(formattedCode).replaceAll("");
 
-        // TODO: Fixing jsoup counting issue which occurs when more than one indentation (jsoup can have mixed line
-        // ending content)
+        // XXX: Fixing jsoup counter issue when more than one character indentation until jsoup fixes bug.
         if (this.formatter.indentAmount() > 1) {
             int lineSize;
             int newLineSize;
             int remainder;
+            // jsoup can have mixed line ending content
             String[] lines = formattedCode.split("\\r?\\n");
             List<String> newLines = new ArrayList<>(lines.length);
             for (String line : lines) {

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -102,6 +102,12 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
             formattedCode = String.join(ending.getChars(), newLines);
         }
 
+        // XXX: Adding new line at end of file until jsoup fixes bug.
+        String[] lines = formattedCode.split(ending.getChars());
+        if (!lines[lines.length - 1].equals(ending.getChars())) {
+            formattedCode = formattedCode + ending.getChars();
+        }
+
         if (code.equals(formattedCode)) {
             return null;
         }

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -75,13 +75,16 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
         // but our tests fail to do so thus we are duplicating this until jsoup fixes bug.
         formattedCode = REMOVE_TRAILING_PATTERN.matcher(formattedCode).replaceAll("");
 
+        // XXX: jsoup processing results in mixed line ending content and needs normalized until jsoup fixes bug.
+        String[] lines = formattedCode.split("\\r?\\n");
+        formattedCode = String.join(ending.getChars(), lines);
+
         // XXX: Fixing jsoup counter issue when more than one character indentation until jsoup fixes bug.
         if (this.formatter.indentAmount() > 1) {
             int lineLength;
             int trimLineLength;
             int remainder;
-            // jsoup processing results in mixed line ending content
-            String[] lines = formattedCode.split("\\r?\\n");
+            lines = formattedCode.split(ending.getChars());
             List<String> newLines = new ArrayList<>(lines.length);
             for (String line : lines) {
                 lineLength = line.length();
@@ -103,7 +106,7 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
         }
 
         // XXX: Adding new line at end of file until jsoup fixes bug.
-        String[] lines = formattedCode.split(ending.getChars());
+        lines = formattedCode.split(ending.getChars());
         if (!lines[lines.length - 1].equals(ending.getChars())) {
             formattedCode = formattedCode + ending.getChars();
         }

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -98,6 +98,7 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
                 }
                 newLines.add(line);
             }
+            // normalizes line endings
             formattedCode = String.join(ending.getChars(), newLines);
         }
 

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -99,9 +99,6 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
             formattedCode = String.join(ending.getChars(), newLines);
         }
 
-        // TODO: Fixing jsoup tagging issue where line break doesn't occur (seen in headers)
-        formattedCode = formattedCode.replace("--><!", "-->" + ending.getChars() + "<!");
-
         if (code.equals(formattedCode)) {
             return null;
         }

--- a/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
+++ b/src/test/java/net/revelc/code/formatter/html/HTMLFormatterTest.java
@@ -36,8 +36,8 @@ class HTMLFormatterTest extends AbstractFormatterTest {
     void testDoFormatFile() throws Exception {
         // FIXME Handle linux vs windows since this formatter does not accept line endings
         final var expectedHash = LineEnding.LF.isSystem()
-                ? "6cdee35b88f56f6ce260747605f5a250142de3f6ec656fd72f47013d17a23ac9ada5dc5a3fb40f43c5991dacc9aae23e575d44bb0a37002b8a6262b8086c23f2"
-                : "129fd027d8cc2a470a4599a862c4b5a078cb14d379c1ea2f4265d3b4e29bd01e218185512abe4212e02a911d8d87943ce1ce5043d3f0e98455360cb4353c6e78";
+                ? "6182753e93b40a56497cb1537fff4a7bd69e821a79968e4ce4f80b621cd1268d0146d0ae65cd1715b0998464eb272803fbd479337dde8490019db5d5976744b8"
+                : "74dfab84a7c8584257fe5c3dfe8487ecc36cc601722a93f824c4dd9b888f0e84549dfe9ce1a893c8ab9758268b9cfdfff45e874443261b7839832b8bc588497b";
         final var lineEnding = LineEnding.LF.isSystem() ? LineEnding.LF : LineEnding.CRLF;
         this.twoPassTest(Collections.emptyMap(), new HTMLFormatter(), "someFile.html", expectedHash, lineEnding);
     }


### PR DESCRIPTION
- Use XXX rather than TODO as entries are not really todo's but need called out if upstream fixes
- Pull up line ending normalization as jsoup will cause non normalized data during its process even if file was previously normalized.  This was mixed into another fix.
- Add clarifications within index counter fix.  Issue typically shows up on span, div, a, possibly others where it still adds one extra space in violations to what was asked for index size
- Removed header line break fix as that was fixed in the fork we used and now also fixed in jsoup directly
- Add new line to end of the file

The existing checks were all verified to still be considerations that have not yet been fixed in jsoup pretty print.  There are 4 patches as follows:
- Removal of trailing space on each line
- Normalization of line endings (jsoup processing internally is LF which will cause mixed results in windows)
- Index counter problem resulting in some lines getting 1 extra space typically
- Add new line to end of file if missing