### PR TITLE
[pom] Remove versions plugin from dep management as no longer used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -497,11 +497,6 @@
           <version>3.0.0-M7</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>versions-maven-plugin</artifactId>
-          <version>2.11.0</version>
-        </plugin>
-        <plugin>
           <groupId>org.gaul</groupId>
           <artifactId>modernizer-maven-plugin</artifactId>
           <version>2.4.0</version>


### PR DESCRIPTION
project uses dependabot only and report section for this was removed previously