### PR TITLE
Bump dependency versions for Eclipse 2022-09

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -192,3 +192,7 @@ ver 2.20.0
 ==========
 - Support Eclipse 2022-06 (4.24, JDT 3.30) - requires jdk 11
 
+ver 2.21.0
+==========
+- Support Eclipse 2022-09 (4.25, JDT 3.31) - requires jdk 11
+

--- a/pom.xml
+++ b/pom.xml
@@ -134,14 +134,14 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.13.3</version>
+        <version>2.13.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.9.0</version>
+        <version>5.9.1</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -149,7 +149,7 @@
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.compare.core</artifactId>
-        <version>3.7.0</version>
+        <version>3.7.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
@@ -161,79 +161,79 @@
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.contenttype</artifactId>
-        <version>3.8.100</version>
+        <version>3.8.200</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.expressions</artifactId>
-        <version>3.8.100</version>
+        <version>3.8.200</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.filesystem</artifactId>
-        <version>1.9.400</version>
+        <version>1.9.500</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.jobs</artifactId>
-        <version>3.13.0</version>
+        <version>3.13.100</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.core.resources</artifactId>
-        <version>3.17.0</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.core.runtime</artifactId>
-        <version>3.25.0</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.app</artifactId>
-        <version>1.6.100</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.common</artifactId>
-        <version>3.16.100</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.preferences</artifactId>
-        <version>3.10.1</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.equinox.registry</artifactId>
-        <version>3.11.100</version>
-      </dependency>
-      <dependency>
-        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
-        <groupId>org.eclipse.platform</groupId>
-        <artifactId>org.eclipse.osgi</artifactId>
         <version>3.18.0</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.core.runtime</artifactId>
+        <version>3.26.0</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.app</artifactId>
+        <version>1.6.200</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.common</artifactId>
+        <version>3.16.200</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.preferences</artifactId>
+        <version>3.10.100</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.equinox.registry</artifactId>
+        <version>3.11.200</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
+        <artifactId>org.eclipse.osgi</artifactId>
+        <version>3.18.100</version>
+      </dependency>
+      <dependency>
+        <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
+        <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.team.core</artifactId>
-        <version>3.9.400</version>
+        <version>3.9.500</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
         <groupId>org.eclipse.platform</groupId>
         <artifactId>org.eclipse.text</artifactId>
-        <version>3.12.100</version>
+        <version>3.12.200</version>
       </dependency>
       <dependency>
         <!-- transitive dependency of org.eclipse.jdt.core resolved here to avoid version range -->
@@ -304,9 +304,10 @@
       <version>3.4.2</version>
     </dependency>
     <dependency>
+      <!-- bump this and run src/build/find-transitive-eclipse-updates.sh to update eclipse deps -->
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.30.0</version>
+      <version>3.31.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>

--- a/src/site/markdown/eclipse-versions.md.vm
+++ b/src/site/markdown/eclipse-versions.md.vm
@@ -26,6 +26,7 @@ their compatibility with major Eclipse releases.
 
 formatter-maven-plugin | Eclipse<br/>Name | Eclipse<br/>Version | JDT Core | JDK<br/>Version
 -----------------------|------------------|---------------------|----------|----------------
+2.21                   | 2022-09          | 4.25                | 3.31     | 11
 2.20                   | 2022-06          | 4.24                | 3.30     | 11
 2.19                   | 2022-03          | 4.23                | 3.29     | 11
 2.18                   | 2021-12          | 4.22                | 3.28     | 11


### PR DESCRIPTION
* Bump JDT Core to 3.31.0
* Bump transitive dependencies for JDT Core using src/build/find-transitive-eclipse-updates.sh script, but leave osgi at 8.1.0 and not 8.0.1 (apparently, Eclipse still depends on 8.0, but 8.1 works fine). Also note that the JDT Core POM model is incorrect and says 4.0, when it should be 4.0.0. This caused a parse error running this script, but was trivial to patch the POM temporarily to get the script to work
* Update Jackson to latest patch release
* Update JUnit to altest
* Update version table for website and CHANGELOG