### PR TITLE
Align usage better with maven slf4j usage, bump few versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -292,6 +292,12 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-digester3</artifactId>
       <version>3.2</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -313,6 +319,11 @@
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
       <version>1.15.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>1.7.36</version>
     </dependency>
     <dependency>
       <groupId>org.w3c.css</groupId>
@@ -643,6 +654,8 @@
                 <ignored>commons-beanutils:commons-beanutils</ignored>
                 <!-- ignore alignment with jackson annotations -->
                 <ignored>com.fasterxml.jackson.core:jackson-annotations</ignored>
+                <!-- ignore alignment with jcl-over-slf4j as we intentially dropped commons logging -->
+                <ignored>org.slf4j:jcl-over-slf4j</ignored>
               </ignoredUnusedDeclaredDependencies>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -512,7 +512,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
-          <version>3.0.0-M7</version>
+          <version>3.0.0-M8</version>
         </plugin>
         <plugin>
           <!-- this is kept to more easily run manual checks for updates -->

--- a/pom.xml
+++ b/pom.xml
@@ -351,7 +351,7 @@
     <dependency>
       <groupId>org.apache.maven.plugin-tools</groupId>
       <artifactId>maven-plugin-annotations</artifactId>
-      <version>3.7.0</version>
+      <version>3.7.1</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -272,6 +272,12 @@
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <version>1.9.4</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -472,7 +472,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-project-info-reports-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.4.2</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -339,7 +339,7 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
-      <version>3.8.6</version>
+      <version>3.8.7</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
       <dependency>
         <groupId>org.junit</groupId>
         <artifactId>junit-bom</artifactId>
-        <version>5.9.1</version>
+        <version>5.9.2</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -422,7 +422,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-dependency-plugin</artifactId>
-          <version>3.4.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
commons-logging as independent library is long obsolete and should not come into our stack.  Given maven is slf4j based, use jcl-over-slf4j as a direct replacement so that logging, if any, actually is picked up from that transient usage.

Update few other dependencies recently released.