### PR TITLE
Update fluido skin and require JDK 17 to build

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [11, 17]
+        java: [17]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -114,7 +114,7 @@
   </distributionManagement>
 
   <properties>
-    <maven-fluido-skin.version>1.11.2</maven-fluido-skin.version>
+    <maven-fluido-skin.version>2.0.0-M2</maven-fluido-skin.version>
 
     <!-- all 3 are needed, because some plugins might use the source/target variables -->
     <maven.compiler.release>11</maven.compiler.release>
@@ -676,7 +676,7 @@
               <version>[3.5.0,)</version>
             </requireMavenVersion>
             <requireJavaVersion>
-              <version>[11,)</version>
+              <version>[17,)</version>
             </requireJavaVersion>
           </rules>
         </configuration>


### PR DESCRIPTION
Building the site does not work in 2.22.0 without these changes, because of the updates to the tycho transitive dependencies that are analyzed during the build of the site, and because of constraints on the version of doxia for the site build.

This change bumps fluido to the latest, and makes JDK 17 the minimum version required to build, so these restrictions are explicit in future releases.