### PR TITLE
Enforce mismatch with prerequisites

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
   </developers>
 
   <prerequisites>
-    <maven>3.3.9</maven>
+    <maven>3.5.0</maven>
   </prerequisites>
 
   <scm>


### PR DESCRIPTION
Hi

I have tried to rebuild the project, but there is a mismatch between prerequisites (maven 3..3.9) and enforce (maven 3.5.0) 
I have updated the prerequisites to 5.5.0

ciao
matteo