### PR TITLE
Review and update provided Eclipse configs

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -944,7 +944,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      */
     private Map<String, String> getFormattingOptions(final String newConfigFile) throws MojoExecutionException {
         if (this.useEclipseDefaults) {
-            this.getLog().info("Using Ecipse Defaults");
+            this.getLog().info("Using Eclipse Defaults");
             // Use defaults only for formatting
             final Map<String, String> options = new HashMap<>();
             options.put(JavaCore.COMPILER_SOURCE, this.compilerSource);

--- a/src/main/resources/formatter-maven-plugin/eclipse/java.xml
+++ b/src/main/resources/formatter-maven-plugin/eclipse/java.xml
@@ -14,8 +14,8 @@
     limitations under the License.
 
 -->
-<profiles version="22">
-<profile kind="CodeFormatterProfile" name="formatter" version="22">
+<profiles version="23">
+<profile kind="CodeFormatterProfile" name="formatter" version="23">
 <setting id="org.eclipse.jdt.core.formatter.align_assignment_statements_on_columns" value="false"/>
 <setting id="org.eclipse.jdt.core.formatter.align_fields_grouping_blank_lines" value="2147483647"/>
 <setting id="org.eclipse.jdt.core.formatter.align_selector_in_method_invocation_on_expression_first_line" value="false"/>
@@ -56,6 +56,7 @@
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameterized_type_references" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_constructor_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_parameters_in_method_declaration" value="16"/>
+<setting id="org.eclipse.jdt.core.formatter.alignment_for_permitted_types_in_type_declaration" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_record_components" value="16"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_relational_operator" value="0"/>
 <setting id="org.eclipse.jdt.core.formatter.alignment_for_resources_in_try" value="120"/>


### PR DESCRIPTION
* Update provided java.xml Eclipse JDT formatter config for 2023-03
* Review javascript.xml for the same, but no changes
* Fix minor typo in spelling of 'eclipse' in a log message