### PR TITLE
[pom] Upgrade to non deprecated maven plugin report plugin 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -755,7 +755,8 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-plugin-plugin</artifactId>
+        <artifactId>maven-plugin-report-plugin</artifactId>
+        <version>3.8.1</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
This is still in the maven-plugin project but 'report' is now deprecated and last 3 releases this was the new support.  With new maven 3.9.0 to show warnings, it became clear it was switched.  Made appropriate change here - nothing else to change.