### PR TITLE
[pom] Remove invalid phase from plugin plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -737,14 +737,12 @@
             <goals>
               <goal>descriptor</goal>
             </goals>
-            <phase>process-classes</phase>
           </execution>
           <execution>
             <id>help-descriptor</id>
             <goals>
               <goal>helpmojo</goal>
             </goals>
-            <phase>process-classes</phase>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
Phases were not needed and help mojo was wrong.  As such, package-info.java does not get auto created during complication and as such modular is not possible.  Fixing this by removing the phases.

The modular issue is that it requires package-info.java which we cannot add in this case as its maven generation code.  Maven as known does that with compiler when missing.  To see this in practice, use javadocs plugin and set to 11 compliance and for the first 100 issues there, make the main eclipse file exclude everything so it can become obvious to the issue.  Its hard to do that, I have that on my fork, I plan to make it modular compliant and I'm nearly there (one would think osgi did their job but clearly not).  I'll push other related changes later, this one though is easy, look at the docs from maven.  Phases were not needed to be calleda nd as noted the one was wrong.