### PR TITLE
Require JDK 17 explicitly in POM and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ mvn clean verify
 ## JDK Requirements
 - 2.16.x requires jdk 8 as required by Eclipse binaries
 - 2.17.x and later requires jdk 11 as required by Eclipse binaries
+- 2.24.x and later requires jdk 17 as required by Eclipse binaries
 
 [Eclipse]: https://eclipse.org
 [Maven]: https://maven.apache.org

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
   <parent>
     <groupId>net.revelc.code</groupId>
     <artifactId>revelc</artifactId>
-    <version>4</version>
+    <version>5</version>
   </parent>
   <groupId>net.revelc.code.formatter</groupId>
   <artifactId>formatter-maven-plugin</artifactId>
@@ -72,8 +72,7 @@
     <formatter.xml.skip>true</formatter.xml.skip>
     <impsort.groups>java.,javax.,org.,com.,net.</impsort.groups>
     <javadoc.doclint>all</javadoc.doclint>
-    <maven.compiler.release>11</maven.compiler.release>
-    <revelc.min-build-jdk>17</revelc.min-build-jdk>
+    <maven.compiler.release>17</maven.compiler.release>
   </properties>
   <dependencyManagement>
     <dependencies>


### PR DESCRIPTION
Version 2.24.0 will require JDK 17, so this change makes it the runtime target version, so that it explicitly requires JDK 17, for fast failure and errors don't show up later unexpectedly when calling into the Eclipse libraries at runtime. Also update the README. Notably, the website docs were already updated to indicate it is required as part of the PR #812