### PR TITLE
Fix JSON handling of LineEnding.KEEP

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -929,13 +929,17 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         // Xml Setup
         if (this.configXmlFile != null) {
             final var xmlFormattingOptions = this.getOptionsFromPropertiesFile(this.configXmlFile);
-            xmlFormattingOptions.put("lineending", this.lineEnding.getChars());
+            if (this.lineEnding != LineEnding.KEEP) {
+                xmlFormattingOptions.put("lineending", this.lineEnding.getChars());
+            }
             this.xmlFormatter.init(xmlFormattingOptions, this);
         }
         // Json Setup
         if (this.configJsonFile != null) {
             final var jsonFormattingOptions = this.getOptionsFromPropertiesFile(this.configJsonFile);
-            jsonFormattingOptions.put("lineending", this.lineEnding.getChars());
+            if (this.lineEnding != LineEnding.KEEP) {
+                jsonFormattingOptions.put("lineending", this.lineEnding.getChars());
+            }
             this.jsonFormatter.init(jsonFormattingOptions, this);
         }
         // Css Setup

--- a/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
@@ -18,6 +18,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.regex.Pattern;
 
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
@@ -38,6 +39,8 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
 
     /** The formatter. */
     private ObjectMapper formatter;
+
+    private static final Pattern ANY_EOL = Pattern.compile("\\R");
 
     @Override
     public void init(final Map<String, String> options, final ConfigurationSource cfg) {
@@ -82,7 +85,7 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
             final Iterator<Object> jsonObjectIterator = this.formatter.readValues(jsonParser, Object.class);
             while (jsonObjectIterator.hasNext()) {
                 String jsonString = this.formatter.writer().writeValueAsString(jsonObjectIterator.next());
-                stringWriter.write(jsonString.strip().replaceAll("\\R", ending.getChars()));
+                stringWriter.write(ANY_EOL.matcher(jsonString.strip()).replaceAll(ending.getChars()));
                 stringWriter.write(ending.getChars());
             }
             String formattedCode = stringWriter.toString();

--- a/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
@@ -79,11 +79,10 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
     protected String doFormat(final String code, final LineEnding ending) throws IOException {
         try (StringWriter stringWriter = new StringWriter()) {
             JsonParser jsonParser = this.formatter.createParser(code);
-            // note: line ending set in init for this usecase
             final Iterator<Object> jsonObjectIterator = this.formatter.readValues(jsonParser, Object.class);
             while (jsonObjectIterator.hasNext()) {
                 String jsonString = this.formatter.writer().writeValueAsString(jsonObjectIterator.next());
-                stringWriter.write(jsonString);
+                stringWriter.write(jsonString.strip().replaceAll("\\R", ending.getChars()));
                 stringWriter.write(ending.getChars());
             }
             String formattedCode = stringWriter.toString();


### PR DESCRIPTION
Do not initialize Json formatter with KEEP line ending. Instead, ensure that the output replaces the default lineendings with the user's preferred endings, whether it's specified or detected by KEEP.

This fixes #827