### PR TITLE
[pom] Add missing relativePath set to nothing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,7 @@
     <groupId>net.revelc.code</groupId>
     <artifactId>revelc</artifactId>
     <version>5</version>
+    <relativePath />
   </parent>
   <groupId>net.revelc.code.formatter</groupId>
   <artifactId>formatter-maven-plugin</artifactId>


### PR DESCRIPTION
Parent poms that don't exist up one level, they need to not look up one level but instead look to m2 cache immediately.  In my case I have a pom level one up that is for cleaning my workspace and maven will issue configuration warnings stating this must be added and its best practice when using a parent pom that is not in same project.