### PR TITLE
[caching] Rewrite d1d5852 fixing #757

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -729,8 +729,8 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         log.debug("Processing file: " + file);
         final var originalCode = this.readFileAsString(file);
 
-        // Default to original hashing, adjust based on appropriate file type for inclusion of formatter options
-        var originalHash = this.sha512hash(originalCode);
+        // Default to original hashing for unknown type otherwise include formatter options
+        String originalHash;
         if (file.getName().endsWith(".java")) {
             originalHash = this.sha512hash(originalCode + this.javaFormatter.getOptions().hashCode());
         } else if (file.getName().endsWith(".js")) {
@@ -743,6 +743,8 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             originalHash = this.sha512hash(originalCode + this.jsonFormatter.getOptions().hashCode());
         } else if (file.getName().endsWith(".css")) {
             originalHash = this.sha512hash(originalCode + this.cssFormatter.getOptions().hashCode());
+        } else {
+            originalHash = this.sha512hash(originalCode);
         }
 
         final var canonicalPath = file.getCanonicalPath();
@@ -831,8 +833,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         if (Result.SKIPPED.equals(result)) {
             formattedHash = originalHash;
         } else {
-            // Default to formatted hashing, adjust based on appropriate file type for inclusion of formatter options
-            formattedHash = this.sha512hash(originalCode);
+            // Default to formatted hashing for unknown type otherwise include formatter options
             if (file.getName().endsWith(".java")) {
                 formattedHash = this.sha512hash(originalCode + this.javaFormatter.getOptions().hashCode());
             } else if (file.getName().endsWith(".js")) {
@@ -845,6 +846,8 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
                 formattedHash = this.sha512hash(originalCode + this.jsonFormatter.getOptions().hashCode());
             } else if (file.getName().endsWith(".css")) {
                 formattedHash = this.sha512hash(originalCode + this.cssFormatter.getOptions().hashCode());
+            } else {
+                formattedHash = this.sha512hash(originalCode);
             }
         }
         hashCache.setProperty(path, formattedHash);

--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -728,7 +728,22 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         final var log = this.getLog();
         log.debug("Processing file: " + file);
         final var originalCode = this.readFileAsString(file);
-        final var originalHash = this.sha512hash(originalCode + this.javaFormatter.hashCode());
+
+        // Default to original hashing, adjust based on appropriate file type for inclusion of formatter options
+        var originalHash = this.sha512hash(originalCode);
+        if (file.getName().endsWith(".java")) {
+            originalHash = this.sha512hash(originalCode + this.javaFormatter.getOptions().hashCode());
+        } else if (file.getName().endsWith(".js")) {
+            originalHash = this.sha512hash(originalCode + this.jsFormatter.getOptions().hashCode());
+        } else if (file.getName().endsWith(".html")) {
+            originalHash = this.sha512hash(originalCode + this.htmlFormatter.getOptions().hashCode());
+        } else if (file.getName().endsWith(".xml")) {
+            originalHash = this.sha512hash(originalCode + this.xmlFormatter.getOptions().hashCode());
+        } else if (file.getName().endsWith(".json")) {
+            originalHash = this.sha512hash(originalCode + this.jsonFormatter.getOptions().hashCode());
+        } else if (file.getName().endsWith(".css")) {
+            originalHash = this.sha512hash(originalCode + this.cssFormatter.getOptions().hashCode());
+        }
 
         final var canonicalPath = file.getCanonicalPath();
         final var path = canonicalPath.substring(basedirPath.length());
@@ -816,7 +831,21 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         if (Result.SKIPPED.equals(result)) {
             formattedHash = originalHash;
         } else {
-            formattedHash = this.sha512hash(formattedCode + this.javaFormatter.hashCode());
+            // Default to formatted hashing, adjust based on appropriate file type for inclusion of formatter options
+            formattedHash = this.sha512hash(originalCode);
+            if (file.getName().endsWith(".java")) {
+                formattedHash = this.sha512hash(originalCode + this.javaFormatter.getOptions().hashCode());
+            } else if (file.getName().endsWith(".js")) {
+                formattedHash = this.sha512hash(originalCode + this.jsFormatter.getOptions().hashCode());
+            } else if (file.getName().endsWith(".html")) {
+                formattedHash = this.sha512hash(originalCode + this.htmlFormatter.getOptions().hashCode());
+            } else if (file.getName().endsWith(".xml")) {
+                formattedHash = this.sha512hash(originalCode + this.xmlFormatter.getOptions().hashCode());
+            } else if (file.getName().endsWith(".json")) {
+                formattedHash = this.sha512hash(originalCode + this.jsonFormatter.getOptions().hashCode());
+            } else if (file.getName().endsWith(".css")) {
+                formattedHash = this.sha512hash(originalCode + this.cssFormatter.getOptions().hashCode());
+            }
         }
         hashCache.setProperty(path, formattedHash);
         this.hashCacheWritten = true;

--- a/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
@@ -38,6 +38,9 @@ public class CssFormatter extends AbstractCacheableFormatter implements Formatte
     /** The formatter. */
     private CSSFormat formatter;
 
+    /** The configuration options */
+    private Map<String, String> options;
+
     @Override
     public void init(final Map<String, String> options, final ConfigurationSource cfg) {
         super.initCfg(cfg);
@@ -48,6 +51,7 @@ public class CssFormatter extends AbstractCacheableFormatter implements Formatte
                 .parseBoolean(options.getOrDefault("useSourceStringValues", Boolean.FALSE.toString()));
         this.formatter = new CSSFormat().setPropertiesInSeparateLines(indent).setRgbAsHex(rgbAsHex)
                 .setUseSourceStringValues(useSourceStringValues);
+        this.options = options;
     }
 
     @Override
@@ -76,6 +80,15 @@ public class CssFormatter extends AbstractCacheableFormatter implements Formatte
     @Override
     public boolean isInitialized() {
         return this.formatter != null;
+    }
+
+    /**
+     * Gets the options.
+     *
+     * @return the options
+     */
+    public Map<String, String> getOptions() {
+        return options;
     }
 
 }

--- a/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/java/JavaFormatter.java
@@ -17,7 +17,6 @@ package net.revelc.code.formatter.java;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.eclipse.jdt.core.ToolFactory;
@@ -47,22 +46,6 @@ public class JavaFormatter extends AbstractCacheableFormatter implements Formatt
 
     /** The configuration options */
     private Map<String, String> options;
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (o == null || getClass() != o.getClass())
-            return false;
-        JavaFormatter that = (JavaFormatter) o;
-        return Objects.equals(formatter, that.formatter) && Objects.equals(exclusionPattern, that.exclusionPattern)
-                && Objects.equals(options, that.options);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(formatter, exclusionPattern, options);
-    }
 
     @Override
     public void init(final Map<String, String> options, final ConfigurationSource cfg) {
@@ -138,6 +121,15 @@ public class JavaFormatter extends AbstractCacheableFormatter implements Formatt
         }
         regions.add(new Region(start, code.length() - start));
         return regions.toArray(new IRegion[0]);
+    }
+
+    /**
+     * Gets the options.
+     *
+     * @return the options
+     */
+    public Map<String, String> getOptions() {
+        return options;
     }
 
 }

--- a/src/main/java/net/revelc/code/formatter/javascript/JavascriptFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/javascript/JavascriptFormatter.java
@@ -35,11 +35,15 @@ public class JavascriptFormatter extends AbstractCacheableFormatter implements F
     /** The formatter. */
     private CodeFormatter formatter;
 
+    /** The configuration options */
+    private Map<String, String> options;
+
     @Override
     public void init(final Map<String, String> options, final ConfigurationSource cfg) {
         super.initCfg(cfg);
 
         this.formatter = ToolFactory.createCodeFormatter(options, ToolFactory.M_FORMAT_EXISTING);
+        this.options = options;
     }
 
     @Override
@@ -65,6 +69,15 @@ public class JavascriptFormatter extends AbstractCacheableFormatter implements F
     @Override
     public boolean isInitialized() {
         return this.formatter != null;
+    }
+
+    /**
+     * Gets the options.
+     *
+     * @return the options
+     */
+    public Map<String, String> getOptions() {
+        return options;
     }
 
 }

--- a/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
@@ -42,6 +42,9 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
 
     private static final Pattern ANY_EOL = Pattern.compile("\\R");
 
+    /** The configuration options */
+    public Map<String, String> options;
+
     @Override
     public void init(final Map<String, String> options, final ConfigurationSource cfg) {
         super.initCfg(cfg);
@@ -76,6 +79,7 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
         this.formatter.setDefaultPrettyPrinter(printer);
         this.formatter.enable(SerializationFeature.INDENT_OUTPUT);
         this.formatter.configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, useAlphabeticalOrder);
+        this.options = options;
     }
 
     @Override
@@ -96,6 +100,15 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
     @Override
     public boolean isInitialized() {
         return this.formatter != null;
+    }
+
+    /**
+     * Gets the options.
+     *
+     * @return the options
+     */
+    public Map<String, String> getOptions() {
+        return options;
     }
 
 }

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -47,6 +47,9 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
     /** The formatter. */
     private OutputSettings formatter;
 
+    /** The configuration options */
+    private Map<String, String> options;
+
     @Override
     public void init(final Map<String, String> options, final ConfigurationSource cfg) {
         super.initCfg(cfg);
@@ -59,6 +62,7 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
         this.formatter.outline(Boolean.parseBoolean(options.getOrDefault("outlineMode", Boolean.TRUE.toString())));
         this.formatter.prettyPrint(Boolean.parseBoolean(options.getOrDefault("pretty", Boolean.TRUE.toString())));
         this.formatter.syntax(Syntax.valueOf(options.getOrDefault("syntax", Syntax.html.name())));
+        this.options = options;
     }
 
     @Override
@@ -126,6 +130,15 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
     @Override
     public boolean isInitialized() {
         return this.formatter != null;
+    }
+
+    /**
+     * Gets the options.
+     *
+     * @return the options
+     */
+    public Map<String, String> getOptions() {
+        return options;
     }
 
 }

--- a/src/main/java/net/revelc/code/formatter/xml/XMLFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/xml/XMLFormatter.java
@@ -31,6 +31,9 @@ public class XMLFormatter extends AbstractCacheableFormatter implements Formatte
     /** The formatter. */
     private XmlDocumentFormatter formatter;
 
+    /** The configuration options */
+    private Map<String, String> options;
+
     @Override
     public void init(final Map<String, String> options, final ConfigurationSource cfg) {
         super.initCfg(cfg);
@@ -45,6 +48,7 @@ public class XMLFormatter extends AbstractCacheableFormatter implements Formatte
         prefs.setDeleteBlankLines(Boolean.parseBoolean(options.getOrDefault("deleteBlankLines", "false")));
 
         this.formatter = new XmlDocumentFormatter(options.getOrDefault("lineending", System.lineSeparator()), prefs);
+        this.options = options;
     }
 
     @Override
@@ -61,6 +65,15 @@ public class XMLFormatter extends AbstractCacheableFormatter implements Formatte
     @Override
     public boolean isInitialized() {
         return this.formatter != null;
+    }
+
+    /**
+     * Gets the options.
+     *
+     * @return the options
+     */
+    public Map<String, String> getOptions() {
+        return options;
     }
 
 }


### PR DESCRIPTION
fixes #757

Original change in d1d5852 only addressed java and did so at detriment of all formatters.  This caused certain platforms to continually update the cache file on every build.  As seen on GitHub, Linux and Macos would change the *nix hashes for every file constantly including java.  For Windows on Github, it was changing the entire file (not clear as to why entire file but that was observed over and over).  Testing to show issue was done with 2.23.0 formatter release that introduced the problem.