### PR TITLE
[fix] Add missing check for json to config checks

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -948,7 +948,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
         }
         // stop the process if not config files where found
         if (javaFormattingOptions == null && jsFormattingOptions == null && this.configHtmlFile == null
-                && this.configXmlFile == null && this.configCssFile == null) {
+                && this.configXmlFile == null && this.configJsonFile == null && this.configCssFile == null) {
             throw new MojoExecutionException(
                     "You must provide a Java, Javascript, HTML, XML, JSON, or CSS configuration file.");
         }


### PR DESCRIPTION
Error notes all 6 formatters but only 5 were being checked.  Corrected so all 6 are checked.