### PR TITLE
[GHA] Change caching to built in from setup-java

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -24,12 +24,7 @@ jobs:
       with:
         java-version: ${{ matrix.java }}
         distribution: zulu
-    - name: Cache local maven repository
-      uses: actions/cache@v4
-      with:
-        path: ~/.m2
-        key: ${{ matrix.os }}-m2-${{ hashFiles('**/pom.xml') }}
-        restore-keys: ${{ matrix.os }}-m2
+        cache: 'maven'
     - name: Build with Maven
       run: mvn -B -V -e "-Dstyle.color=always" verify -DskipFormat -DverifyFormat
       env:


### PR DESCRIPTION
See https://github.com/actions/setup-java?tab=readme-ov-file#caching-packages-dependencies as this is built in now.