### PR TITLE
[tests] Add slf4j-simple to tests to clear warnings and correct jcl version to 1.7.36

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -274,12 +274,18 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>jcl-over-slf4j</artifactId>
-      <version>2.0.12</version>
+      <version>1.7.36</version>
     </dependency>
     <dependency>
       <groupId>org.w3c.css</groupId>
       <artifactId>sac</artifactId>
       <version>1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.36</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
slf4j overrides maven, it must remain the same revision.  When it is not, the service loader will not properly find the version used and throws warnings with slf4j.  In this case, test on simple is required as its the test that runs into the issue.  This produces a proper stack trace after resolved.

Dependabot will need to be informed on this repo to not suggest 2.x.  We an only upgrade when maven does or we override maven entirely which historically has not been the intent of this repo.