### PR TITLE
[pom] Use plexus xml 3.0.0 or we lose maven 3 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,6 +261,11 @@
       <version>4.0.0</version>
     </dependency>
     <dependency>
+      <groupId>org.codehaus.plexus</groupId>
+      <artifactId>plexus-xml</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+    <dependency>
       <!-- bump this and run src/build/find-transitive-eclipse-updates.sh to update eclipse deps -->
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
@@ -301,6 +306,8 @@
             <ignore>com.fasterxml.jackson.core:jackson-annotations</ignore>
             <!-- ignore alignment with jcl-over-slf4j as we intentially dropped commons logging -->
             <ignore>org.slf4j:jcl-over-slf4j</ignore>
+            <!-- ignore alignment with plexus-xml as required to ensure plexus-utils uses maven 3 -->
+            <ignore>org.codehaus.plexus:plexus-xml</ignore>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>


### PR DESCRIPTION
Plexus utils 4.0.0 brings in maven 4 apis which should not be in the build.  In many cases it breaks compatibility with maven 3 especially earlier versions indicated supported here.  Maven created a non maven 4 copy of plexus-xml that should be defined for this specific purpose.  We should however try to stop relying on plexus utils as its mostly deprecated.