### PR TITLE
[var] since majority of 'var' is used, used the rest

### DIFF
--- a/src/main/java/net/revelc/code/formatter/FormatterMojo.java
+++ b/src/main/java/net/revelc/code/formatter/FormatterMojo.java
@@ -44,7 +44,6 @@ import org.apache.maven.model.Resource;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
-import org.apache.maven.plugin.logging.Log;
 import org.apache.maven.plugins.annotations.Component;
 import org.apache.maven.plugins.annotations.LifecyclePhase;
 import org.apache.maven.plugins.annotations.Mojo;
@@ -486,7 +485,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
             final var duration = NANOSECONDS.toMillis(System.nanoTime() - startClock);
             final var elapsed = TimeUtil.printDuration(duration);
 
-            final String results = String.format(
+            final var results = String.format(
                     "Processed %d files in %s (Formatted: %d, Skipped: %d, Unchanged: %d, Failed: %d, Readonly: %d)",
                     numberOfFiles, elapsed, rc.successCount, rc.skippedCount, rc.unchangedCount, rc.failCount,
                     rc.readOnlyCount);
@@ -542,7 +541,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
     private List<File> addCollectionFiles(final Resource resource) {
         final var newBasedir = new File(resource.getDirectory());
         if (!newBasedir.exists()) {
-            final Log log = getLog();
+            final var log = getLog();
             if (log.isDebugEnabled()) {
                 log.debug(String.format("Skipping non-existing directory %s", newBasedir));
             }
@@ -605,7 +604,7 @@ public class FormatterMojo extends AbstractMojo implements ConfigurationSource {
      */
     private void storeFileHashCache(final Properties props) {
         final var cacheFile = Path.of(this.cachedir.getAbsolutePath(), CACHE_PROPERTIES_FILENAME);
-        try (StringWriter sw = new StringWriter()) {
+        try (var sw = new StringWriter()) {
             props.store(sw, null);
             getLog().debug("Writing sorted files to cache without timestamp:\n\n" + props);
             Files.write(cacheFile, (Iterable<String>) sw.toString().lines().skip(1).sorted()::iterator,

--- a/src/main/java/net/revelc/code/formatter/ValidateMojo.java
+++ b/src/main/java/net/revelc/code/formatter/ValidateMojo.java
@@ -75,7 +75,7 @@ public class ValidateMojo extends FormatterMojo {
         super.doFormatFile(file, rc, hashCache, basedirPath, true);
 
         if (rc.successCount != 0) {
-            String errorMessage = String.format(
+            var errorMessage = String.format(
                     "File '%s' has not been previously formatted. Please format file (for example by invoking `%s`) and commit before running validation!",
                     file, formatCommand());
             throw new MojoFailureException(errorMessage);
@@ -86,11 +86,10 @@ public class ValidateMojo extends FormatterMojo {
     }
 
     private String formatCommand() {
-        String mojoInvocation = String.format("%s:%s:%s:%s", mojoGroupId, mojoArtifactId, mojoVersion,
-                FORMAT_MOJO_NAME);
-        boolean isMultiModule = mavenSession.getAllProjects().size() > 1;
-        Path moduleDir = Path.of(".").toAbsolutePath().relativize(mavenProject.getBasedir().toPath().toAbsolutePath());
-        String specifyModule = isMultiModule ? String.format("-f %s", moduleDir) : "";
+        var mojoInvocation = String.format("%s:%s:%s:%s", mojoGroupId, mojoArtifactId, mojoVersion, FORMAT_MOJO_NAME);
+        var isMultiModule = mavenSession.getAllProjects().size() > 1;
+        var moduleDir = Path.of(".").toAbsolutePath().relativize(mavenProject.getBasedir().toPath().toAbsolutePath());
+        var specifyModule = isMultiModule ? String.format("-f %s", moduleDir) : "";
         return String.format("mvn %s %s", specifyModule, mojoInvocation).replace("  ", " ");
     }
 

--- a/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/css/CssFormatter.java
@@ -66,7 +66,7 @@ public class CssFormatter extends AbstractCacheableFormatter implements Formatte
         formattedCode = formattedCode.replace("\t;", "\\9;");
 
         // Adding new line at end of file when needed
-        String[] lines = formattedCode.split(ending.getChars(), -1);
+        var lines = formattedCode.split(ending.getChars(), -1);
         if (!lines[lines.length - 1].equals(ending.getChars())) {
             formattedCode = formattedCode + ending.getChars();
         }

--- a/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/json/JsonFormatter.java
@@ -20,7 +20,6 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.regex.Pattern;
 
-import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.util.DefaultIndenter;
 import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.core.util.Separators;
@@ -85,15 +84,15 @@ public class JsonFormatter extends AbstractCacheableFormatter implements Formatt
 
     @Override
     protected String doFormat(final String code, final LineEnding ending) throws IOException {
-        try (StringWriter stringWriter = new StringWriter()) {
-            JsonParser jsonParser = this.formatter.createParser(code);
+        try (var stringWriter = new StringWriter()) {
+            var jsonParser = this.formatter.createParser(code);
             final Iterator<Object> jsonObjectIterator = this.formatter.readValues(jsonParser, Object.class);
             while (jsonObjectIterator.hasNext()) {
-                String jsonString = this.formatter.writer().writeValueAsString(jsonObjectIterator.next());
+                var jsonString = this.formatter.writer().writeValueAsString(jsonObjectIterator.next());
                 stringWriter.write(ANY_EOL.matcher(jsonString.strip()).replaceAll(ending.getChars()));
                 stringWriter.write(ending.getChars());
             }
-            String formattedCode = stringWriter.toString();
+            var formattedCode = stringWriter.toString();
             return code.equals(formattedCode) ? null : formattedCode;
         }
     }

--- a/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
+++ b/src/main/java/net/revelc/code/formatter/jsoup/JsoupBasedFormatter.java
@@ -84,7 +84,7 @@ public abstract class JsoupBasedFormatter extends AbstractCacheableFormatter imp
         // XXX: Jsoup results in mixed line ending content needing normalized until jsoup
         // provides line ending support. Internally Jsoup simply uses new line only and
         // mixture comes from lines that did not require additional formatting.
-        String[] lines = formattedCode.split("\\r?\\n");
+        var lines = formattedCode.split("\\r?\\n");
         formattedCode = String.join(ending.getChars(), lines);
 
         // XXX: Fixing jsoup counter issue when more than one character indentation until jsoup fixes bug.


### PR DESCRIPTION
'var' is not hard to understand.  Its already stating directly what it is by the right hand side.  This is still type safe.  Further its just the opposite of diamond operation.  Java provided this for a valid reason, we end up with less imports, cleaner code, and lose nothing using it.

This was already done in mass a long time back because code base moved above java 10.  Being consistent at this point as very little is not done.