### PR TITLE
[GHA] Run in far more instances

### DIFF
--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
-        java: [17, 21, 22-ea, 23-ea]
+        java: [17, 21]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/maven.yaml
+++ b/.github/workflows/maven.yaml
@@ -9,8 +9,8 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
-        java: [17]
+        os: [ubuntu-latest, windows-latest, macos-latest, macos-14]
+        java: [17, 21, 22-ea, 23-ea]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:
@@ -19,7 +19,7 @@ jobs:
       uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
-        distribution: zulu
+        distribution: temurin
         cache: 'maven'
     - name: Build with Maven
       run: mvn -B -V -e "-Dstyle.color=always" verify -DskipFormat -DverifyFormat


### PR DESCRIPTION
we need to show our repo works with newer jdks, not just the min one.  Move from zulu to temurin.  And add macos-14 as that is the m1 chip.