### PR TITLE
[pom] Bump jsdt-core to 3.4.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -222,7 +222,7 @@
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>
       <artifactId>jsdt-core</artifactId>
-      <version>3.3.0</version>
+      <version>3.4.2</version>
     </dependency>
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>


### PR DESCRIPTION
Modified delivery of this artifact now only includes what is necessary which reduces size of jar from 35mb to 5mb.