### PR TITLE
Use maven to deploy site

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,11 @@
     <javadoc.doclint>all</javadoc.doclint>
     <maven.compiler.release>17</maven.compiler.release>
 
+    <!-- Remove the following after next parent update -->
+    <version.maven-fluido-skin>2.0.0-M9</version.maven-fluido-skin>
+    <version.maven-site-plugin>4.0.0-M15</version.maven-site-plugin>
+    <maven.site.deploy.skip>false</maven.site.deploy.skip>
+
     <!-- Allow newer invoker for higher jdk support -->
     <version.maven-invoker-plugin>3.7.0</version.maven-invoker-plugin>
   </properties>

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -14,7 +14,7 @@
     limitations under the License.
 
 -->
-<project name="${project.name}" xmlns="http://maven.apache.org/site/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<site name="${project.name}" xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
     <skin>
         <groupId>org.apache.maven.skins</groupId>
@@ -46,4 +46,4 @@
         </menu>
         <menu ref="reports" />
     </body>
-</project>
+</site>


### PR DESCRIPTION
Site xsd was wrongly implemented and site.xsd requires site 4 milestones and fluido 2 milestones.  Fixed all that then enabled site to generate from maven.  The upstream site should be removed.  Its 9 years old and not supported.  For single module projects, maven's site generates and releases ok.  The 2.24.0 release didn't push any release for site and it appears to have been manually done for 2.23.0.  This should fix it so it generates properly.  The results looked the same when I spot checked the entire thing.  The comments to remove items would apply once upstream joins using modernized site deployment via maven release (again for single modules, its still entirely broken for multi module).