### PR TITLE
[pom] Site still did not release, add scm data to allow it to occur

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,14 @@
   <scm>
     <tag>HEAD</tag>
   </scm>
+  <distributionManagement>
+    <site>
+      <id>gh-pages</id>
+      <name>Formatter Maven Plugin GitHub Pages</name>
+      <url>scm:git:ssh://git@github.com/revelc/formatter-maven-plugin.git</url>
+    </site>
+  </distributionManagement>
+
   <properties>
     <formatter.configFile>${project.basedir}/src/main/resources/formatter-maven-plugin/eclipse/java.xml</formatter.configFile>
     <formatter.css.skip>true</formatter.css.skip>
@@ -319,6 +327,16 @@
           <excludes combine.children="append">
             <exclude>CHANGELOG.md</exclude>
           </excludes>
+        </configuration>
+      </plugin>
+      <!-- Release still doesn't publish site automately due to overrides on release, to use this run: mvn site site:stage scm-publish:publish-scm -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-scm-publish-plugin</artifactId>
+        <version>3.2.1</version>
+        <configuration>
+          <scmBranch>gh-pages</scmBranch>
+          <tryUpdate>true</tryUpdate>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
actual issue is all the overrides on release that are not needed.  Fall to scm as that is the standard way maven suggests now even though release wants site.  Reduced version of what I use in hazendaz/base-parent just enough to get it to go.  The release still won't do it but left instructions on here to do this on demand.  Takes maybe minute or two.  Site is now updated which is an improvement.  This alone below will do nothing without running the commands listed.