### PR TITLE
Rewrite pom for better support along with updating outstanding library versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -218,7 +218,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.38.0</version>
+      <version>3.40.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -124,12 +124,6 @@
       <groupId>commons-beanutils</groupId>
       <artifactId>commons-beanutils</artifactId>
       <version>1.10.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -145,39 +139,11 @@
       <groupId>net.revelc.code.formatter</groupId>
       <artifactId>jsdt-core</artifactId>
       <version>3.5.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.osgi</groupId>
-          <artifactId>org.osgi.util.function</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.osgi</groupId>
-          <artifactId>osgi.annotation</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.revelc.code.formatter</groupId>
       <artifactId>xml-formatter</artifactId>
       <version>0.4.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>slf4j-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>net.sourceforge.cssparser</groupId>
@@ -188,27 +154,11 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-digester3</artifactId>
       <version>3.2</version>
-      <exclusions>
-        <exclusion>
-          <groupId>commons-beanutils</groupId>
-          <artifactId>commons-beanutils</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-resources</artifactId>
       <version>1.3.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.codehaus.plexus</groupId>
-          <artifactId>plexus-utils</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
@@ -230,12 +180,6 @@
       <groupId>org.osgi</groupId>
       <artifactId>org.osgi.util.function</artifactId>
       <version>1.2.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.osgi</groupId>
-          <artifactId>osgi.annotation</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <!-- converge dependency with jsdt-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <!-- override vulnerable transitive version from commons-digester3 -->
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.10.1</version>
+      </dependency>
+      <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>9.7.1</version>
@@ -130,12 +136,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.4.0-jre</version>
-    </dependency>
-    <dependency>
-      <!-- override vulnerable transitive version from commons-digester3 -->
-      <groupId>commons-beanutils</groupId>
-      <artifactId>commons-beanutils</artifactId>
-      <version>1.10.1</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>
@@ -233,7 +233,6 @@
                 <dependencyConvergence>
                   <!-- The items listed below have been verified non issue for allowing. -->
                   <excludes>
-                    <exclude>commons-beanutils:commons-beanutils</exclude>
                     <exclude>commons-logging:commons-logging</exclude>
                     <exclude>com.google.guava:guava</exclude>
                     <exclude>com.google.errorprone:error_prone_annotations</exclude>
@@ -255,7 +254,6 @@
         <configuration>
           <!-- The items listed below have been verified non issue to override. -->
           <ignoredUnusedDeclaredDependencies>
-            <ignore>commons-beanutils:commons-beanutils</ignore>
             <ignore>commons-logging:commons-logging</ignore>
             <ignore>com.google.errorprone:error_prone_annotations</ignore>
             <!-- converge dependency with jsdt-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
         <version>2.36.0</version>
       </dependency>
       <dependency>
+        <groupId>com.google.guava</groupId>
+        <artifactId>guava</artifactId>
+        <version>33.4.0-jre</version>
+      </dependency>
+      <dependency>
         <!-- override vulnerable transitive version from commons-digester3 -->
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
@@ -146,7 +151,6 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>33.4.0-jre</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -233,7 +237,6 @@
                 <dependencyConvergence>
                   <!-- The items listed below have been verified non issue for allowing. -->
                   <excludes>
-                    <exclude>com.google.guava:guava</exclude>
                     <exclude>org.codehaus.plexus:plexus-utils</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.equinox.common</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.core.runtime</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -224,7 +224,19 @@
             <phase>validate</phase>
             <configuration>
               <rules>
-                <dependencyConvergence />
+                <dependencyConvergence>
+                  <excludes>
+                    <exclude>commons-beanutils:commons-beanutils</exclude>
+                    <exclude>commons-logging:commons-logging</exclude>
+                    <exclude>com.google.guava:guava</exclude>
+                    <exclude>com.google.errorprone:error_prone_annotations</exclude>
+                    <exclude>org.codehaus.plexus:plexus-utils</exclude>
+                    <exclude>org.eclipse.platform:org.eclipse.equinox.common</exclude>
+                    <exclude>org.eclipse.platform:org.eclipse.core.runtime</exclude>
+                    <exclude>org.osgi:osgi.annotation</exclude>
+                    <exclude>org.osgi:org.osgi.util.function</exclude>
+                  </excludes>
+                </dependencyConvergence>
               </rules>
             </configuration>
           </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -86,7 +86,7 @@
       <dependency>
         <groupId>com.fasterxml.jackson</groupId>
         <artifactId>jackson-bom</artifactId>
-        <version>2.18.2</version>
+        <version>2.18.3</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -199,7 +199,7 @@
     <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
-      <version>1.18.3</version>
+      <version>1.19.1</version>
     </dependency>
     <dependency>
       <groupId>org.w3c.css</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -126,6 +126,12 @@
         <artifactId>commons-logging</artifactId>
         <version>1.3.5</version>
       </dependency>
+      <dependency>
+        <!-- converge dependency with jsdt-core -->
+        <groupId>org.osgi</groupId>
+        <artifactId>osgi.annotation</artifactId>
+        <version>8.1.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -188,12 +194,6 @@
       <version>1.18.3</version>
     </dependency>
     <dependency>
-      <!-- converge dependency with jsdt-core -->
-      <groupId>org.osgi</groupId>
-      <artifactId>osgi.annotation</artifactId>
-      <version>8.1.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.w3c.css</groupId>
       <artifactId>sac</artifactId>
       <version>1.3</version>
@@ -237,7 +237,6 @@
                     <exclude>org.codehaus.plexus:plexus-utils</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.equinox.common</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.core.runtime</exclude>
-                    <exclude>org.osgi:osgi.annotation</exclude>
                     <exclude>org.osgi:org.osgi.util.function</exclude>
                   </excludes>
                 </dependencyConvergence>
@@ -245,17 +244,6 @@
             </configuration>
           </execution>
         </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <configuration>
-          <!-- The items listed below have been verified non issue to override. -->
-          <ignoredUnusedDeclaredDependencies>
-            <!-- converge dependency with jsdt-core -->
-            <ignore>org.osgi:osgi.annotation</ignore>
-          </ignoredUnusedDeclaredDependencies>
-        </configuration>
       </plugin>
     </plugins>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,11 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>4.0.2</version>
+      </dependency>
+      <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>9.7.1</version>
@@ -185,7 +190,6 @@
     <dependency>
       <groupId>org.codehaus.plexus</groupId>
       <artifactId>plexus-utils</artifactId>
-      <version>4.0.2</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
@@ -237,7 +241,6 @@
                 <dependencyConvergence>
                   <!-- The items listed below have been verified non issue for allowing. -->
                   <excludes>
-                    <exclude>org.codehaus.plexus:plexus-utils</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.equinox.common</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.core.runtime</exclude>
                     <exclude>org.osgi:org.osgi.util.function</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -121,6 +121,11 @@
         <artifactId>commons-beanutils</artifactId>
         <version>1.10.1</version>
       </dependency>
+      <dependency>
+        <groupId>commons-logging</groupId>
+        <artifactId>commons-logging</artifactId>
+        <version>1.3.5</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
@@ -136,11 +141,6 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
       <version>33.4.0-jre</version>
-    </dependency>
-    <dependency>
-      <groupId>commons-logging</groupId>
-      <artifactId>commons-logging</artifactId>
-      <version>1.3.5</version>
     </dependency>
     <dependency>
       <groupId>javax.inject</groupId>
@@ -233,7 +233,6 @@
                 <dependencyConvergence>
                   <!-- The items listed below have been verified non issue for allowing. -->
                   <excludes>
-                    <exclude>commons-logging:commons-logging</exclude>
                     <exclude>com.google.guava:guava</exclude>
                     <exclude>org.codehaus.plexus:plexus-utils</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.equinox.common</exclude>
@@ -253,7 +252,6 @@
         <configuration>
           <!-- The items listed below have been verified non issue to override. -->
           <ignoredUnusedDeclaredDependencies>
-            <ignore>commons-logging:commons-logging</ignore>
             <!-- converge dependency with jsdt-core -->
             <ignore>org.osgi:osgi.annotation</ignore>
           </ignoredUnusedDeclaredDependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -223,6 +223,7 @@
             <configuration>
               <rules>
                 <dependencyConvergence>
+                  <!-- The items listed below have been verified non issue for allowing. -->
                   <excludes>
                     <exclude>cglib:cglib</exclude>
                     <exclude>commons-beanutils:commons-beanutils</exclude>
@@ -246,12 +247,10 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
+          <!-- The items listed below have been verified non issue to override. -->
           <ignoredUnusedDeclaredDependencies>
-            <!-- ignore transient dependency overridden to get newer asm jdk support -->
             <ignored>cglib:cglib</ignored>
-            <!-- ignore transitive dependency overridden to avoid vulnerability -->
             <ignore>commons-beanutils:commons-beanutils</ignore>
-            <!-- ignore alignment with commons-logging to support slf4j -->
             <ignore>commons-logging:commons-logging</ignore>
             <!-- ignore transitive dependency on error prone annotations -->
             <ignore>com.google.errorprone:error_prone_annotations</ignore>

--- a/pom.xml
+++ b/pom.xml
@@ -91,13 +91,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.ow2.asm</groupId>
-        <artifactId>asm</artifactId>
-        <version>9.7.1</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
         <version>2.0.17</version>
@@ -105,12 +98,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <!-- override outdated transitive version from commons-digester3 -->
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
         <version>3.3.0</version>
       </dependency>
       <dependency>
-        <!-- converge dependency with jsdt-core -->
+        <!-- converge dependency between our guava and jsdt-core's gson -->
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
         <version>2.36.0</version>
@@ -127,6 +121,7 @@
         <version>1.10.1</version>
       </dependency>
       <dependency>
+        <!-- converge commons-digester3 transitive dependency -->
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.3.5</version>
@@ -137,10 +132,22 @@
         <version>4.0.2</version>
       </dependency>
       <dependency>
-        <!-- converge dependency with jsdt-core -->
+        <!-- resolve jsdt-core convergence problem -->
+        <groupId>org.osgi</groupId>
+        <artifactId>org.osgi.util.function</artifactId>
+        <version>1.2.0</version>
+      </dependency>
+      <dependency>
+        <!-- resolve jsdt-core convergence problem -->
         <groupId>org.osgi</groupId>
         <artifactId>osgi.annotation</artifactId>
         <version>8.1.0</version>
+      </dependency>
+      <dependency>
+        <!-- override outdated transitive version from commons-digester3 -->
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.7.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -239,11 +246,9 @@
             <configuration>
               <rules>
                 <dependencyConvergence>
-                  <!-- The items listed below have been verified non issue for allowing. -->
                   <excludes>
-                    <exclude>org.eclipse.platform:org.eclipse.equinox.common</exclude>
-                    <exclude>org.eclipse.platform:org.eclipse.core.runtime</exclude>
-                    <exclude>org.osgi:org.osgi.util.function</exclude>
+                    <!-- Eclipse is bad at dependency convergence, so ignore them -->
+                    <exclude>org.eclipse.platform:*</exclude>
                   </excludes>
                 </dependencyConvergence>
               </rules>

--- a/pom.xml
+++ b/pom.xml
@@ -104,14 +104,14 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+      <dependency>
+        <groupId>cglib</groupId>
+        <artifactId>cglib</artifactId>
+        <version>3.3.0</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>
-    <dependency>
-      <groupId>cglib</groupId>
-      <artifactId>cglib</artifactId>
-      <version>3.3.0</version>
-    </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
@@ -233,7 +233,6 @@
                 <dependencyConvergence>
                   <!-- The items listed below have been verified non issue for allowing. -->
                   <excludes>
-                    <exclude>cglib:cglib</exclude>
                     <exclude>commons-beanutils:commons-beanutils</exclude>
                     <exclude>commons-logging:commons-logging</exclude>
                     <exclude>com.google.guava:guava</exclude>
@@ -256,7 +255,6 @@
         <configuration>
           <!-- The items listed below have been verified non issue to override. -->
           <ignoredUnusedDeclaredDependencies>
-            <ignored>cglib:cglib</ignored>
             <ignore>commons-beanutils:commons-beanutils</ignore>
             <ignore>commons-logging:commons-logging</ignore>
             <ignore>com.google.errorprone:error_prone_annotations</ignore>

--- a/pom.xml
+++ b/pom.xml
@@ -176,18 +176,6 @@
       <version>1.18.3</version>
     </dependency>
     <dependency>
-      <!-- converge dependency with jsdt-core -->
-      <groupId>org.osgi</groupId>
-      <artifactId>org.osgi.util.function</artifactId>
-      <version>1.2.0</version>
-    </dependency>
-    <dependency>
-      <!-- converge dependency with jsdt-core -->
-      <groupId>org.osgi</groupId>
-      <artifactId>osgi.annotation</artifactId>
-      <version>8.1.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.w3c.css</groupId>
       <artifactId>sac</artifactId>
       <version>1.3</version>
@@ -251,10 +239,8 @@
             <ignore>commons-beanutils:commons-beanutils</ignore>
             <!-- ignore alignment with commons-logging to support slf4j -->
             <ignore>commons-logging:commons-logging</ignore>
-            <!-- ignore unused osgi items added only for transitive dependency convergence-->
+            <!-- ignore transitive dependency on error prone annotations -->
             <ignore>com.google.errorprone:error_prone_annotations</ignore>
-            <ignore>org.osgi:org.osgi.util.function</ignore>
-            <ignore>org.osgi:osgi.annotation</ignore>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>org.codehaus.plexus</groupId>
-        <artifactId>plexus-utils</artifactId>
-        <version>4.0.2</version>
-      </dependency>
-      <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>9.7.1</version>
@@ -135,6 +130,11 @@
         <groupId>commons-logging</groupId>
         <artifactId>commons-logging</artifactId>
         <version>1.3.5</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <version>4.0.2</version>
       </dependency>
       <dependency>
         <!-- converge dependency with jsdt-core -->

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,11 @@
   </dependencyManagement>
   <dependencies>
     <dependency>
+      <groupId>cglib</groupId>
+      <artifactId>cglib</artifactId>
+      <version>3.3.0</version>
+    </dependency>
+    <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-core</artifactId>
     </dependency>
@@ -214,6 +219,7 @@
               <rules>
                 <dependencyConvergence>
                   <excludes>
+                    <exclude>cglib:cglib</exclude>
                     <exclude>commons-beanutils:commons-beanutils</exclude>
                     <exclude>commons-logging:commons-logging</exclude>
                     <exclude>com.google.guava:guava</exclude>
@@ -235,6 +241,8 @@
         <artifactId>maven-dependency-plugin</artifactId>
         <configuration>
           <ignoredUnusedDeclaredDependencies>
+            <!-- ignore transient dependency overridden to get newer asm jdk support -->
+            <ignored>cglib:cglib</ignored>
             <!-- ignore transitive dependency overridden to avoid vulnerability -->
             <ignore>commons-beanutils:commons-beanutils</ignore>
             <!-- ignore alignment with commons-logging to support slf4j -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.ow2.asm</groupId>
+        <artifactId>asm</artifactId>
+        <version>9.7.1</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
         <version>2.0.16</version>
@@ -187,11 +194,6 @@
       <version>8.1.0</version>
     </dependency>
     <dependency>
-      <groupId>org.ow2.asm</groupId>
-      <artifactId>asm</artifactId>
-      <version>9.7.1</version>
-    </dependency>
-    <dependency>
       <groupId>org.w3c.css</groupId>
       <artifactId>sac</artifactId>
       <version>1.3</version>
@@ -241,7 +243,6 @@
                     <exclude>org.eclipse.platform:org.eclipse.core.runtime</exclude>
                     <exclude>org.osgi:osgi.annotation</exclude>
                     <exclude>org.osgi:org.osgi.util.function</exclude>
-                    <exclude>org.ow2.asm:asm</exclude>
                   </excludes>
                 </dependencyConvergence>
               </rules>
@@ -261,7 +262,6 @@
             <ignore>com.google.errorprone:error_prone_annotations</ignore>
             <!-- converge dependency with jsdt-core -->
             <ignore>org.osgi:osgi.annotation</ignore>
-            <ignore>org.ow2.asm:asm</ignore>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,11 @@
       <version>1.18.3</version>
     </dependency>
     <dependency>
+      <groupId>org.ow2.asm</groupId>
+      <artifactId>asm</artifactId>
+      <version>9.7.1</version>
+    </dependency>
+    <dependency>
       <groupId>org.w3c.css</groupId>
       <artifactId>sac</artifactId>
       <version>1.3</version>
@@ -229,6 +234,7 @@
                     <exclude>org.eclipse.platform:org.eclipse.core.runtime</exclude>
                     <exclude>org.osgi:osgi.annotation</exclude>
                     <exclude>org.osgi:org.osgi.util.function</exclude>
+                    <exclude>org.ow2.asm:asm</exclude>
                   </excludes>
                 </dependencyConvergence>
               </rules>
@@ -249,6 +255,7 @@
             <ignore>commons-logging:commons-logging</ignore>
             <!-- ignore transitive dependency on error prone annotations -->
             <ignore>com.google.errorprone:error_prone_annotations</ignore>
+            <ignore>org.ow2.asm:asm</ignore>
           </ignoredUnusedDeclaredDependencies>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -91,12 +91,6 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <!-- override vulnerable transitive version from commons-digester3 -->
-        <groupId>commons-beanutils</groupId>
-        <artifactId>commons-beanutils</artifactId>
-        <version>1.10.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
         <version>9.7.1</version>
@@ -114,6 +108,12 @@
         <groupId>cglib</groupId>
         <artifactId>cglib</artifactId>
         <version>3.3.0</version>
+      </dependency>
+      <dependency>
+        <!-- override vulnerable transitive version from commons-digester3 -->
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <version>1.10.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,12 @@
       <version>1.18.3</version>
     </dependency>
     <dependency>
+      <!-- converge dependency with jsdt-core -->
+      <groupId>org.osgi</groupId>
+      <artifactId>osgi.annotation</artifactId>
+      <version>8.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm</artifactId>
       <version>9.7.1</version>
@@ -252,8 +258,9 @@
             <ignored>cglib:cglib</ignored>
             <ignore>commons-beanutils:commons-beanutils</ignore>
             <ignore>commons-logging:commons-logging</ignore>
-            <!-- ignore transitive dependency on error prone annotations -->
             <ignore>com.google.errorprone:error_prone_annotations</ignore>
+            <!-- converge dependency with jsdt-core -->
+            <ignore>org.osgi:osgi.annotation</ignore>
             <ignore>org.ow2.asm:asm</ignore>
           </ignoredUnusedDeclaredDependencies>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-bom</artifactId>
-        <version>2.0.16</version>
+        <version>2.0.17</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,12 @@
         <version>3.3.0</version>
       </dependency>
       <dependency>
+        <!-- converge dependency with jsdt-core -->
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>2.36.0</version>
+      </dependency>
+      <dependency>
         <!-- override vulnerable transitive version from commons-digester3 -->
         <groupId>commons-beanutils</groupId>
         <artifactId>commons-beanutils</artifactId>
@@ -125,12 +131,6 @@
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>
       <artifactId>jackson-databind</artifactId>
-    </dependency>
-    <dependency>
-      <!-- converge dependency with jsdt-core -->
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.36.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>
@@ -235,7 +235,6 @@
                   <excludes>
                     <exclude>commons-logging:commons-logging</exclude>
                     <exclude>com.google.guava:guava</exclude>
-                    <exclude>com.google.errorprone:error_prone_annotations</exclude>
                     <exclude>org.codehaus.plexus:plexus-utils</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.equinox.common</exclude>
                     <exclude>org.eclipse.platform:org.eclipse.core.runtime</exclude>
@@ -255,7 +254,6 @@
           <!-- The items listed below have been verified non issue to override. -->
           <ignoredUnusedDeclaredDependencies>
             <ignore>commons-logging:commons-logging</ignore>
-            <ignore>com.google.errorprone:error_prone_annotations</ignore>
             <!-- converge dependency with jsdt-core -->
             <ignore>org.osgi:osgi.annotation</ignore>
           </ignoredUnusedDeclaredDependencies>


### PR DESCRIPTION
- Bump jdt core to 3.40.0
- Bump jsdt core to 3.5.0
- No longer exclude any libraries unless 100% necessary as tools do not show relationships and dependency convergence is on
- Do not worry about libraries we vetted that are ok with dependency convergence issues
- Drop part of the osgi overrides as no longer needed
- Use the last cglib to avoid any potential issues (at least until apache commons team finally releases digester upgrade after 14 years)  I expect this to be removed at that time.
- Override asm for same reason as cglib (the only required exclusion is here because group id change).  I expect this to be removed once digester new release is made.
- Adjust comments around how we handle convergence or override usage
- Drop commons lang3 as it was used once to check for empty, just check that directly