### PR TITLE
Bump parent POM to 8 and update site sources

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,15 +19,16 @@
   <parent>
     <groupId>net.revelc.code</groupId>
     <artifactId>revelc</artifactId>
-    <version>7</version>
+    <version>8</version>
     <relativePath />
   </parent>
   <groupId>net.revelc.code.formatter</groupId>
   <artifactId>formatter-maven-plugin</artifactId>
   <version>2.27.0-SNAPSHOT</version>
   <packaging>maven-plugin</packaging>
-  <name>formatter-maven-plugin</name>
+  <name>Formatter Maven Plugin</name>
   <description>Maven plugin for formatting source code</description>
+  <url>https://code.revelc.net/formatter-maven-plugin</url>
   <inceptionYear>2010</inceptionYear>
   <developers>
     <developer>

--- a/src/site/markdown/index.md.vm
+++ b/src/site/markdown/index.md.vm
@@ -16,13 +16,16 @@
 
 #set ($d = "$")
 
-Introduction
-============
+${project.name}
+===============
 
 ${project.description}
 
-This plugin allows formatting java source code using the Eclipse code
-formatter.
+This `${project.artifactId}` allows formatting java source code using the Eclipse code
+formatter, as well as formatting files of other types.
+
+Introduction
+------------
 
 For a description on how to begin using the plugin, see the [usage] section.
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -14,36 +14,37 @@
     limitations under the License.
 
 -->
-<project name="${project.name}" xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
-    <skin>
-        <groupId>org.apache.maven.skins</groupId>
-        <artifactId>maven-fluido-skin</artifactId>
-        <version>${version.maven-fluido-skin}</version>
-    </skin>
-    <custom>
-        <fluidoSkin>
-            <topBarEnabled>true</topBarEnabled>
-            <sideBarEnabled>true</sideBarEnabled>
-        </fluidoSkin>
-    </custom>
-    <body>
-        <menu name="Overview">
-            <item name="Project Home" href="https://code.revelc.net/formatter-maven-plugin/"/>
-            <item name="Introduction" href="index.html"/>
-            <item name="Goals" href="plugin-info.html"/>
-            <item name="Usage" href="usage.html"/>
-            <item name="Eclipse Compatibility" href="eclipse-versions.html"/>
-            <item name="Examples" href="examples.html"/>
-        </menu>
-        <menu name="Examples">
-            <item name="Source Files" href="examples.html#Setting_Source_Files"/>
-            <item name="Compiler Version" href="examples.html#Setting_Compiler_Version"/>
-            <item name="Line Endings" href="examples.html#System_Independent_Line_Endings"/>
-            <item name="File Encoding" href="examples.html#Source_File_Encoding"/>
-            <item name="Custom Formatting" href="examples.html#Custom_Configuration_File"/>
-            <item name="Multimodule" href="examples.html#Multimodule_Configuration"/>
-        </menu>
-        <menu ref="reports" />
-    </body>
-</project>
+<site xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SITE/2.0.0 https://maven.apache.org/xsd/site-2.0.0.xsd">
+  <skin>
+    <groupId>org.apache.maven.skins</groupId>
+    <artifactId>maven-fluido-skin</artifactId>
+    <version>${version.maven-fluido-skin}</version>
+  </skin>
+  <custom>
+    <fluidoSkin>
+      <topBarEnabled>true</topBarEnabled>
+      <sideBarEnabled>true</sideBarEnabled>
+      <skipGenerationDate>true</skipGenerationDate>
+      <sourceLineNumbersEnabled>true</sourceLineNumbersEnabled>
+    </fluidoSkin>
+  </custom>
+  <body>
+    <menu name="Overview">
+      <item name="About" href="index.html"/>
+      <item name="Goals" href="plugin-info.html"/>
+      <item name="Usage" href="usage.html"/>
+      <item name="Eclipse Compatibility" href="eclipse-versions.html"/>
+      <item name="Examples" href="examples.html"/>
+    </menu>
+    <menu name="Examples">
+      <item name="Source Files" href="examples.html#Setting_Source_Files"/>
+      <item name="Compiler Version" href="examples.html#Setting_Compiler_Version"/>
+      <item name="Line Endings" href="examples.html#System_Independent_Line_Endings"/>
+      <item name="File Encoding" href="examples.html#Source_File_Encoding"/>
+      <item name="Custom Formatting" href="examples.html#Custom_Configuration_File"/>
+      <item name="Multimodule" href="examples.html#Multimodule_Configuration"/>
+    </menu>
+    <menu ref="reports" />
+  </body>
+</site>


### PR DESCRIPTION
* Update parent POM to version 8
* Make project.name human-readable
* Add project.url
* Add project.name to markdown site and other small improvements to the layout of the site's main page
* Remove redundant "Project Home" link from site
* Rename "Introduction" menu entry for main page to "About" to match the page name in the generated reports
* Update the site descriptor to use the 2.0.0 schema for the latest maven-site-plugin and fluido skin and to add a few useful options