### PR TITLE
Update JDT for Eclipse 2025-06

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <!-- converge dependency between our guava and jsdt-core's gson -->
         <groupId>com.google.errorprone</groupId>
         <artifactId>error_prone_annotations</artifactId>
-        <version>2.38.0</version>
+        <version>2.39.0</version>
       </dependency>
       <dependency>
         <!-- converge dependency between our guava and jsdt-core's gson -->
@@ -137,6 +137,12 @@
         <!-- resolve dependency convergence issue with Eclipse -->
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
+        <version>5.17.0</version>
+      </dependency>
+      <dependency>
+        <!-- resolve dependency convergence issue with Eclipse and jsdt-core -->
+        <groupId>net.java.dev.jna</groupId>
+        <artifactId>jna-platform</artifactId>
         <version>5.17.0</version>
       </dependency>
       <dependency>
@@ -214,7 +220,7 @@
     <dependency>
       <groupId>org.eclipse.jdt</groupId>
       <artifactId>org.eclipse.jdt.core</artifactId>
-      <version>3.41.0</version>
+      <version>3.42.0</version>
     </dependency>
     <dependency>
       <groupId>org.jsoup</groupId>

--- a/src/site/markdown/eclipse-versions.md.vm
+++ b/src/site/markdown/eclipse-versions.md.vm
@@ -26,6 +26,7 @@ their compatibility with major Eclipse releases.
 
 formatter-maven-plugin | Eclipse<br/>Name | Eclipse<br/>Version | JDT Core | JDK<br/>Version
 -----------------------|------------------|---------------------|----------|----------------
+2.28                   | 2025-06          | 4.36                | 3.42     | 17
 2.27                   | 2025-03          | 4.35                | 3.41     | 17
 2.26                   | 2024-12          | 4.34                | 3.40     | 17
 2.25                   | 2024-06          | 4.32                | 3.38     | 17


### PR DESCRIPTION
Also update errorprone annotations because a newer one was available